### PR TITLE
fix: adjust example events api url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-EVENTS_API_URL=http://localhost:3000
+EVENTS_API_URL=http://localhost:3001
 SITE_URL=http://localhost:3000


### PR DESCRIPTION
Changing the API URL to prevent the app from self fetching loop making the `/` route unavailable.

