### PR TITLE
feat: Mock Crossweb Events API

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,2 @@
-EVENTS_API_URL=http://localhost:3001
+EVENTS_API_URL=http://localhost:3000/api/mocked/crossweb
 SITE_URL=http://localhost:3000

--- a/src/app/api/mocked/crossweb/route.ts
+++ b/src/app/api/mocked/crossweb/route.ts
@@ -1,0 +1,91 @@
+import { EventsType } from '@/types/event';
+
+export const GET = async (request: Request) =>
+	new URL(request.url).searchParams.get('old') === '1'
+		? Response.json(pastEventsJson)
+		: Response.json(upcomingEventsJson);
+
+const upcomingEventsJson: EventsType = {
+	'1': {
+		id: 60579,
+		date_add: 1733499629,
+		date: '17.12.2024',
+		time: '18:00',
+		name: '#60 meet.js Bia\u0142ystok',
+		type: 'Spotkanie',
+		url: 'https://crossweb.pl/wydarzenia/60-meet-js-bialystok/',
+		rsvp: 'https://crossweb.pl/wydarzenia/60-meet-js-bialystok/',
+		city: 'Bia\u0142ystok',
+		address: 'Zwierzyniecka 10',
+		image:
+			'https://crossweb.pl/upload/gallery/event/60579/840x320/469226967_1681239372569204_3996555995980207175_n.jpg',
+		serie: 'meet.js Bia\u0142ystok',
+		topic: ['JavaScript'],
+	},
+};
+
+const pastEventsJson: EventsType = {
+	'1': {
+		id: 60467,
+		date_add: 1732708798,
+		date: '5.12.2024',
+		time: '18:00',
+		name: 'meet.js Łódź 2024/12',
+		type: 'Spotkanie',
+		url: 'https://crossweb.pl/wydarzenia/meet-js-lodz-2024-12/',
+		rsvp: 'https://www.meetup.com/meet-js-lodz/events/304685998/',
+		city: 'Łódź',
+		address: 'ul. Piotrkowska 157/A, 90-440 Łódź',
+		image: 'https://crossweb.pl/upload/gallery/event/60467/840x320/meet.avif',
+		serie: 'meet.js',
+		topic: ['programowanie', 'JavaScript'],
+	},
+	'2': {
+		id: 60079,
+		date_add: 1730377768,
+		date: '28.11.2024',
+		time: '17:30',
+		name: 'meet.js KRK [with GPC]',
+		type: 'Spotkanie',
+		url: 'https://crossweb.pl/wydarzenia/meet-js-krk-with-gpc-listopad-2024/',
+		rsvp: 'http://www.meetup.com/KrakowJS/events/304294369/',
+		city: 'Kraków',
+		address: 'Lubicz 23/a',
+		image:
+			'https://crossweb.pl/upload/gallery/event/60079/840x320/600_524419186.webp',
+		serie: 'meet.js',
+		topic: ['programowanie', 'JavaScript'],
+	},
+	'3': {
+		id: 59929,
+		date_add: 1729589331,
+		date: '18.11.2024',
+		time: '18:00',
+		name: 'meet.js #Poznań #11.2024 #58',
+		type: 'Spotkanie',
+		url: 'https://crossweb.pl/wydarzenia/meet-js-poznan-11-2024-58/',
+		rsvp: '',
+		city: 'Poznań',
+		address: 'Wierzbięcice 1B, Poznań',
+		image:
+			'https://crossweb.pl/upload/gallery/event/59929/840x320/meetjs-58.png',
+		serie: 'meet.js Poznań',
+		topic: ['programowanie', 'JavaScript', 'Angular', 'React', 'TypeScript'],
+	},
+	'4': {
+		id: 60150,
+		date_add: 1731070397,
+		date: '13.11.2024',
+		time: '18:00',
+		name: 'meet.js Wrocław 2024-11-13 x airSlate',
+		type: 'Spotkanie',
+		url: 'https://crossweb.pl/wydarzenia/meet-js-wroclaw-2024-11-13-x-airslate/',
+		rsvp: 'https://www.meetup.com/pl-PL/meet-js-wroclaw/events/304057946/',
+		city: 'Wrocław',
+		address: 'Włodkowica 5',
+		image:
+			'https://crossweb.pl/upload/gallery/event/60150/840x320/1920x1080.png',
+		serie: 'meet.js',
+		topic: ['programowanie', 'JavaScript', 'Angular', 'React', 'TypeScript'],
+	},
+};

--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -15,7 +15,10 @@ export const metadata: Metadata = {
 
 const getPastEvents = async () => {
 	try {
-		const pastEventsRes = await fetch(`${env.EVENTS_API_URL}&old=1`, {
+		const url = new URL(env.EVENTS_API_URL);
+		url.searchParams.set('old', '1');
+
+		const pastEventsRes = await fetch(url, {
 			cache: 'force-cache',
 		});
 

--- a/src/components/FeaturedEvents.tsx
+++ b/src/components/FeaturedEvents.tsx
@@ -21,25 +21,22 @@ export interface Event {
 	rsvp: string;
 	city: string;
 	address: string | null;
+	image: string;
 	serie: string;
 	topic: string[];
-};
+}
 
 export const FeaturedEvents = async () => {
 	const events: Event[] | null = await getUpcomingEvents();
 
 	return (
 		<section
-			className="mx-auto flex w-full max-w-7xl p-12 snap-y scroll-mt-16 flex-col justify-between px-2 lg:px-8 bg-branding-blue"
+			className="bg-branding-blue mx-auto flex w-full max-w-7xl snap-y scroll-mt-16 flex-col justify-between p-12 px-2 lg:px-8"
 			id="events"
 		>
 			<div className="flex w-full flex-col gap-4 p-4">
-				<h2 className="text-center text-3xl font-bold">
-					Upcoming Events
-				</h2>
-				<p className="text-center">
-					Don&apos;t miss these!
-				</p>
+				<h2 className="text-center text-3xl font-bold">Upcoming Events</h2>
+				<p className="text-center">Don&apos;t miss these!</p>
 				{events === null ? (
 					<EmptyEventsAlert />
 				) : (

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -11,6 +11,7 @@ const EventSchema = z.object({
 	rsvp: z.string(),
 	city: z.string().default(''),
 	address: z.string().nullable(),
+	image: z.string().default(''),
 	serie: z.string(),
 	topic: z.array(z.string()).default([]),
 });

--- a/src/utils/getUpcomingEvents.ts
+++ b/src/utils/getUpcomingEvents.ts
@@ -4,7 +4,7 @@ import { changeCityName } from '@/utils/changeCityName';
 
 export const getUpcomingEvents = async () => {
 	try {
-		const upcomingEventsRes = await fetch(env.EVENTS_API_URL);
+		const upcomingEventsRes = await fetch(new URL(env.EVENTS_API_URL));
 
 		const upcomingEventsJson = await upcomingEventsRes.json();
 		const data = EventsSchema.parse(upcomingEventsJson);


### PR DESCRIPTION
Makes https://github.com/naugtur/meetjs.pl/pull/85 obsolete.

This way we can easily develop locally (even offline) without worrying about external API and it's usage (no spamming).
Also resolves the [issue](https://github.com/naugtur/meetjs.pl/pull/85) mentioned above

`IDEA:` We could use some client side pagination for Past Events section - we display all of the past events (events from over 10 years) making it cumbersome scrolling towards the footer. We could chunk it into pages or think about some grid layout.