### PR TITLE
fix: Home page API hard cache via force-dynamic

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,8 @@ import { FeaturedEvents } from '@/components/FeaturedEvents';
 import { HeroSection } from '@/components/HeroSection';
 import { PartnersSection } from '@/components/PartnersSection';
 
+export const dynamic = 'force-dynamic';
+
 const Home = () => {
 	return (
 		<>
@@ -18,9 +20,8 @@ const Home = () => {
 					<Stats />
 				</div>
 				<PartnersSection />
-			</main>  
+			</main>
 		</>
-		
 	);
 };
 


### PR DESCRIPTION
Trying to fix hard cached Events API on the Home page.

As discussed with @dzienisz we could either:
- `cache bust` by adding some semirandom/random **query param** (ex. date with day precision)
- make the page `dynamic`
- convert the `<FeaturedEvents />` component to `client component`

There are many solutions.
https://nextjs.org/docs/app/api-reference/file-conventions/route-segment-config#dynamic

As for now the production has stale data on the home page so we need to invalidate that cache somehow.