### PR TITLE
feat: change /events page styles

### DIFF
--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -47,16 +47,16 @@ const EventsPage = async ({ searchParams }: EventsPageProps) => {
 	const pastEvents = await getPastEvents();
 
 	return (
-		<main className="flex min-h-screen flex-col items-center gap-12 p-5">
-			<section className="flex flex-col items-center justify-center gap-4">
-				<h1 className="text-4xl font-bold">All events</h1>
+		<main className="flex min-h-screen flex-col items-center gap-6 p-5 mx-auto max-w-7xl px-5 sm:px-6 lg:px-8">
+			<section className="flex flex-col items-center justify-center gap-6 w-full">
+				<h1 className="text-4xl font-bold py-4">All events</h1>
 				<p className="text-center text-lg">
 					All meet.js events in one place. Check past and upcoming meetups.
 				</p>
 				<EventsAPIPartner />
 			</section>
 
-			<section className="flex flex-col items-center justify-center gap-12">
+			<section className="flex flex-col items-center justify-center gap-6 w-full">
 				<h2 className="text-2xl font-bold">Upcoming events</h2>
 				{upcomingEvents ? (
 					<EventsList eventsList={upcomingEvents} />
@@ -65,7 +65,7 @@ const EventsPage = async ({ searchParams }: EventsPageProps) => {
 				)}
 			</section>
 
-			<section className="flex flex-col items-center justify-center gap-12">
+			<section className="flex flex-col items-center justify-center gap-6 w-full">
 				<h2 className="text-2xl font-bold">Past events</h2>
 				<FilterEvents events={pastEvents} filter={city} />
 			</section>

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -32,7 +32,7 @@ export const EventCard = ({ event }: EventCardProps) => {
 
 	return (
 		<Card className={cn(
-			"group flex min-h-80 max-w-xl flex-col justify-between transition-all hover:shadow-lg md:min-h-60",
+			"group flex min-h-60 min-w-full flex-col justify-between transition-all hover:shadow-lg",
 			isInProgress && "border-purple dark:border-green border-2"
 		)}>
 			<CardHeader>

--- a/src/components/EventsList.tsx
+++ b/src/components/EventsList.tsx
@@ -7,7 +7,7 @@ interface EventsListProps {
 
 export const EventsList = ({ eventsList }: EventsListProps) => {
 	return (
-		<ul className="flex flex-col gap-4">
+		<ul className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3 w-full">
 			{eventsList.map((event) => {
 				return (
 					<li key={event.id}>

--- a/src/components/FilterEvents.tsx
+++ b/src/components/FilterEvents.tsx
@@ -32,8 +32,8 @@ const FilterEventsContent = ({ events, filter }: FilterEventsProps) => {
 	return (
 		<>
 			<div className="flex flex-col gap-2">
-				<p>Filter events by city:</p>
-				<div className="flex max-w-3xl flex-wrap justify-center gap-2">
+				<p className="text-lg text-center">Filter events by city</p>
+				<div className="flex max-w-4xl flex-wrap justify-center gap-2">
 					<Link
 						href={{ pathname: '/events' }}
 						scroll={false}


### PR DESCRIPTION
Change:
— 3 column grid instead of one column
— shorter tab min height is now 60 not 80 px

New

<img width="1429" alt="Screenshot 2025-02-23 at 14 52 24" src="https://github.com/user-attachments/assets/68c83e5b-82df-4d18-8f76-a2088e3b51b0" />

<img width="683" alt="Screenshot 2025-02-23 at 14 52 06" src="https://github.com/user-attachments/assets/a0cd3196-ecb7-4bec-a9ae-ac671407ede5" />

Old

<img width="1399" alt="Screenshot 2025-02-23 at 14 52 34" src="https://github.com/user-attachments/assets/00521755-641c-4daf-bdc0-31d07e4aef3d" />

<img width="755" alt="Screenshot 2025-02-23 at 14 52 10" src="https://github.com/user-attachments/assets/e8fdb514-b00d-4402-8eaf-b5984e81eeb2" />


