### PR TITLE
fix: Lublin. add missing organizer and fix typo

### DIFF
--- a/src/app/(cities)/lublin/_FAQ.tsx
+++ b/src/app/(cities)/lublin/_FAQ.tsx
@@ -46,7 +46,7 @@ export const LublinFAQ: FAQQuestion[] = [
 		question: 'What does it cost to join event?',
 		answer: (
 			<>
-				Generally our event are FREE! Only{' '}
+				Generally our events are FREE! Only{' '}
 				<a href="https://summit.meetjs.pl" about="_blank">
 					summit
 				</a>{' '}

--- a/src/app/(cities)/lublin/_Organizers.tsx
+++ b/src/app/(cities)/lublin/_Organizers.tsx
@@ -5,5 +5,10 @@ export const LublinOrganizers: Organizer[] = [
 		name: 'Patryk Omiotek',
 		image: 'https://media.licdn.com/dms/image/v2/D4D03AQEE4b1f0BdSWA/profile-displayphoto-shrink_800_800/profile-displayphoto-shrink_800_800/0/1726523493093?e=1748476800&v=beta&t=xuOpEwgpOalNS10CWw9v8tLPmOdc5INWvzttkMhXQ-M',
 		linkedin: 'https://www.linkedin.com/in/patrykomiotek/',
+	},
+	{
+		name: 'Sebastian Mysakowski',
+		image: 'https://media.licdn.com/dms/image/v2/D4D03AQHJqYudYW7bdg/profile-displayphoto-shrink_800_800/profile-displayphoto-shrink_800_800/0/1663656658788?e=1748476800&v=beta&t=Q_Sh2y_ZvPOcSfLX2rogHlScXwKaA9VC6A9yEnXUHa8',
+		linkedin: 'https://www.linkedin.com/in/smysakowski/',
 	}
 ];


### PR DESCRIPTION
This pull request includes updates to the Lublin city section of the application, specifically addressing a typo in the FAQ and adding a new organizer to the list.

Key changes:

* Corrected a typo in the FAQ section to ensure proper grammar and clarity. (`src/app/(cities)/lublin/_FAQ.tsx`)
* Added a new organizer, Sebastian Mysakowski, to the list of Lublin organizers, including his name, image, and LinkedIn profile link. (`src/app/(cities)/lublin/_Organizers.tsx`)

![image](https://github.com/user-attachments/assets/27a7e21d-09f0-482f-9d70-1c750c229e78)
![image](https://github.com/user-attachments/assets/a88e7c57-a02e-4908-8ccb-94dc8381ec37)
