### PR TITLE
feat: Add Banner variants

### DIFF
--- a/src/app/(pages)/wdi/page.tsx
+++ b/src/app/(pages)/wdi/page.tsx
@@ -43,7 +43,7 @@ export default function Page() {
 				</ActionLink>
 			</div>
 
-			<Banner>
+			<Banner variant="warning">
 				{daysRemaining >= 0 ? (
 					<>
 						<p className="font-semibold">Discount ends soon!</p>

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -22,9 +22,9 @@ export const Banner = ({ children, variant = 'info' }: Props) => (
 const getVariantStyles = (variant: Variant) => {
 	switch (variant) {
 		case 'info':
-			return 'bg-blue-50 border-blue-400';
+			return 'bg-sky-50 border-sky-400';
 		case 'success':
-			return 'bg-green-50 border-green-400';
+			return 'bg-emerald-50 border-emerald-400';
 		case 'warning':
 			return 'bg-yellow-50 border-yellow-400';
 		case 'danger':

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -7,7 +7,6 @@ interface Props {
 	variant?: Variant;
 }
 
-// TODO: Introduce variants - https://github.com/naugtur/meetjs.pl/issues/129
 export const Banner = ({ children, variant = 'info' }: Props) => (
 	<article
 		className={classNames(

--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -1,10 +1,35 @@
+import { classNames } from '@/utils/classNames';
+
+type Variant = 'info' | 'success' | 'warning' | 'danger';
+
 interface Props {
 	children: React.ReactNode;
+	variant?: Variant;
 }
 
 // TODO: Introduce variants - https://github.com/naugtur/meetjs.pl/issues/129
-export const Banner = ({ children }: Props) => (
-	<article className="mb-8 border-l-4 border-yellow-400 bg-yellow-50 p-4">
+export const Banner = ({ children, variant = 'info' }: Props) => (
+	<article
+		className={classNames(
+			'mb-8 border-l-4 p-4 shadow-sm',
+			getVariantStyles(variant),
+		)}
+	>
 		{children}
 	</article>
 );
+
+const getVariantStyles = (variant: Variant) => {
+	switch (variant) {
+		case 'info':
+			return 'bg-blue-50 border-blue-400';
+		case 'success':
+			return 'bg-green-50 border-green-400';
+		case 'warning':
+			return 'bg-yellow-50 border-yellow-400';
+		case 'danger':
+			return 'bg-red-50 border-red-400';
+		default:
+			throw new Error(`Unknown Banner variant of "${variant}"`);
+	}
+};


### PR DESCRIPTION
Resolves https://github.com/naugtur/meetjs.pl/issues/129

Adding colour variants for banner component:
- info (blue)
- success (green)
- warning (yellow)
- danger (red)

<img width="891" alt="image" src="https://github.com/user-attachments/assets/189c8d41-2947-4f63-b31c-7dc09b261a6b" />

Also there is an issue with Tailwind class of `blue`, `green` and `purple` as it is overriden in the `/tailwind.config.ts`. We should change the naming to avoid shadowing default tailwind colours.