### PR TITLE
Fixed tailwind base colors shadowing

### DIFF
--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -25,9 +25,9 @@ const config: Config = {
 					'conic-gradient(from 180deg at 50% 50%, var(--tw-gradient-stops))',
 			},
 			colors: {
-				purple: '#2b1932',
-				blue: '#219eab',
-				green: '#bcd35d',
+				Byzantiumpurple: '#2b1932',// dark shade of purple
+				Pacificblue: '#219eab',// shade of blue
+				yellowgreen: '#bcd35d',// a mixture of yellow and green
 				border: 'hsl(var(--border))',
 				input: 'hsl(var(--input))',
 				ring: 'hsl(var(--ring))',


### PR DESCRIPTION
#Description: -
In the tailwind.config file has shades of blue, green, purple as overridden as actual color names. So, I changed them to suitable names.

#closes #146 
