### PR TITLE
Feat/discord refactor

### DIFF
--- a/src/components/DiscordCommunity.tsx
+++ b/src/components/DiscordCommunity.tsx
@@ -1,14 +1,5 @@
+import { Users } from 'lucide-react';
 import { getDiscordServerData } from '@/lib/discord';
-import { MessagesSquare, Users } from 'lucide-react';
-
-interface DiscordCommunityProps {
-	discordData?: {
-		name?: string;
-		approximate_presence_count?: number;
-		invite_url?: string;
-	} | null;
-	error?: string;
-}
 
 export const DiscordCommunity = async () => {
 	const { data, error } = await getDiscordServerData()
@@ -32,15 +23,14 @@ export const DiscordCommunity = async () => {
 							<h4 className="text-lg font-bold">
 								{data.name || 'MeetJS Community'}
 							</h4>
+
 							<p className="mt-1 text-sm text-gray-300">
 								Connect with JavaScript developers
 							</p>
 						</div>
-						{data.approximate_presence_count && (
-							<div className="bg-green-500/20 flex items-center gap-1 rounded-full px-2 py-1 text-sm">
-								<Users className="h-4 w-4" />
-								<span>{data.approximate_presence_count} online</span>
-							</div>
+
+						{data?.approximate_presence_count && (
+							<UsersCount count={data.approximate_member_count ?? 0} />
 						)}
 					</div>
 
@@ -66,4 +56,11 @@ const Loader = () => (
 	<p className="text-gray-500 dark:text-gray-400">
 		Loading community information...
 	</p>
+);
+
+const UsersCount = ({ count }: { count: number }) => (
+	<div className="bg-green-500/20 flex items-center gap-1 rounded-full px-2 py-1 text-sm">
+		<Users className="h-4 w-4" />
+		<span>{count} online</span>
+	</div>
 );

--- a/src/components/DiscordCommunity.tsx
+++ b/src/components/DiscordCommunity.tsx
@@ -1,68 +1,69 @@
+import { getDiscordServerData } from '@/lib/discord';
 import { MessagesSquare, Users } from 'lucide-react';
 
 interface DiscordCommunityProps {
-  discordData?: {
-    name?: string;
-    approximate_presence_count?: number;
-    invite_url?: string;
-  } | null;
-  error?: string;
+	discordData?: {
+		name?: string;
+		approximate_presence_count?: number;
+		invite_url?: string;
+	} | null;
+	error?: string;
 }
 
-export function DiscordCommunity({ discordData, error }: DiscordCommunityProps) {
-  if (error) {
-    return (
-      <div className="mt-4 border-t pt-6">
-        <h3 className="mb-4 flex items-center gap-2 text-xl font-semibold">
-          <MessagesSquare className="h-5 w-5 text-[#5865F2]" />
-          Join our Discord Community
-        </h3>
-        <p className="text-red-500">Error loading Discord data: {error}</p>
-      </div>
-    );
-  }
+export const DiscordWidget = async () => {
+	const { data, error } = await getDiscordServerData()
+		.then((data) => ({ data, error: null }))
+		.catch((e) => ({
+			data: null,
+			error: e instanceof Error ? e.message : 'Failed to load Discord data',
+		}));
 
-  if (!discordData) {
-    return (
-      <div className="mt-4 border-t pt-6">
-        <h3 className="mb-4 flex items-center gap-2 text-xl font-semibold">
-          <MessagesSquare className="h-5 w-5 text-[#5865F2]" />
-          Join our Discord Community
-        </h3>
-        <p className="text-gray-500 dark:text-gray-400">Loading community information...</p>
-      </div>
-    );
-  }
+	if (error) return <ErrorMessage msg={error} />;
+	if (!data) return <Loader />;
 
-  return (
-    <div className="flex flex-col items-center">
-      <div className="relative overflow-hidden bg-gradient-to-br from-[#2f3136] to-[#1e1f22] text-white rounded-lg shadow-xl p-6 w-full max-w-md mb-4 transition-all duration-300 hover:shadow-2xl group">
-        <div className="absolute inset-0 bg-gradient-to-r from-[#5865F2]/10 to-[#5865F2]/5 opacity-0 group-hover:opacity-100 transition-opacity duration-300"></div>
-        
-        <div className="relative z-10">
-          <div className="flex items-center justify-between mb-4">
-            <div>
-              <h4 className="font-bold text-lg">{discordData.name || 'MeetJS Community'}</h4>
-              <p className="text-sm text-gray-300 mt-1">Connect with JavaScript developers</p>
-            </div>
-            {discordData.approximate_presence_count && (
-              <div className="flex items-center gap-1 text-sm bg-green-500/20 px-2 py-1 rounded-full">
-                <Users className="h-4 w-4" />
-                <span>{discordData.approximate_presence_count} online</span>
-              </div>
-            )}
-          </div>
-          
-          <a 
-            href={discordData.invite_url || "https://discord.gg/C6hEh2R4"}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="block w-full bg-gradient-to-r from-[#5865F2] to-[#4752C4] hover:from-[#4752C4] hover:to-[#3a45a5] text-white text-center py-3 rounded-md transition-all duration-300 font-medium transform hover:scale-[1.02] shadow-md"
-          >
-            Join Server
-          </a>
-        </div>
-      </div>
-    </div>
-  );
-}
+	return (
+		<div className="flex flex-col items-center">
+			<div className="group relative mb-4 w-full max-w-md overflow-hidden rounded-lg bg-gradient-to-br from-[#2f3136] to-[#1e1f22] p-6 text-white shadow-xl transition-all duration-300 hover:shadow-2xl">
+				<div className="absolute inset-0 bg-gradient-to-r from-[#5865F2]/10 to-[#5865F2]/5 opacity-0 transition-opacity duration-300 group-hover:opacity-100"></div>
+
+				<div className="relative z-10">
+					<div className="mb-4 flex items-center justify-between">
+						<div>
+							<h4 className="text-lg font-bold">
+								{data.name || 'MeetJS Community'}
+							</h4>
+							<p className="mt-1 text-sm text-gray-300">
+								Connect with JavaScript developers
+							</p>
+						</div>
+						{data.approximate_presence_count && (
+							<div className="bg-green-500/20 flex items-center gap-1 rounded-full px-2 py-1 text-sm">
+								<Users className="h-4 w-4" />
+								<span>{data.approximate_presence_count} online</span>
+							</div>
+						)}
+					</div>
+
+					<a
+						href={data.invite_url || 'https://discord.gg/C6hEh2R4'}
+						target="_blank"
+						rel="noopener noreferrer"
+						className="block w-full transform rounded-md bg-gradient-to-r from-[#5865F2] to-[#4752C4] py-3 text-center font-medium text-white shadow-md transition-all duration-300 hover:scale-[1.02] hover:from-[#4752C4] hover:to-[#3a45a5]"
+					>
+						Join Server
+					</a>
+				</div>
+			</div>
+		</div>
+	);
+};
+
+const ErrorMessage = ({ msg }: { msg: string }) => (
+	<p className="text-red-500">Error loading Discord data: {msg}</p>
+);
+
+const Loader = () => (
+	<p className="text-gray-500 dark:text-gray-400">
+		Loading community information...
+	</p>
+);

--- a/src/components/DiscordCommunity.tsx
+++ b/src/components/DiscordCommunity.tsx
@@ -61,6 +61,6 @@ const Loader = () => (
 const UsersCount = ({ count }: { count: number }) => (
 	<div className="bg-green-500/20 flex items-center gap-1 rounded-full px-2 py-1 text-sm">
 		<Users className="h-4 w-4" />
-		<span>{count} online</span>
+		<span className="text-center">{count} online</span>
 	</div>
 );

--- a/src/components/DiscordCommunity.tsx
+++ b/src/components/DiscordCommunity.tsx
@@ -1,5 +1,7 @@
-import { Users } from 'lucide-react';
 import { getDiscordServerData } from '@/lib/discord';
+import { DiscordWidget } from './DiscordWidget';
+
+const DISCORD_INVITE_LINK = 'https://discord.gg/C6hEh2R4';
 
 export const DiscordCommunity = async () => {
 	const { data, error } = await getDiscordServerData()
@@ -9,59 +11,21 @@ export const DiscordCommunity = async () => {
 			error: e instanceof Error ? e.message : 'Failed to load Discord data',
 		}));
 
-	if (error) return <ErrorMessage msg={error} />;
-	if (!data) return <Loader />;
+	if (error)
+		return <p className="text-red-500">Error loading Discord data: {error}</p>;
+
+	if (!data)
+		return (
+			<p className="text-gray-500 dark:text-gray-400">
+				Loading community information...
+			</p>
+		);
 
 	return (
-		<div className="flex flex-col items-center">
-			<div className="group relative mb-4 w-full max-w-md overflow-hidden rounded-lg bg-gradient-to-br from-[#2f3136] to-[#1e1f22] p-6 text-white shadow-xl transition-all duration-300 hover:shadow-2xl">
-				<div className="absolute inset-0 bg-gradient-to-r from-[#5865F2]/10 to-[#5865F2]/5 opacity-0 transition-opacity duration-300 group-hover:opacity-100"></div>
-
-				<div className="relative">
-					<div className="mb-4 flex items-center justify-between">
-						<div>
-							<h4 className="text-lg font-bold">
-								{data.name || 'MeetJS Community'}
-							</h4>
-
-							<p className="mt-1 text-sm text-gray-300">
-								Connect with JavaScript developers
-							</p>
-						</div>
-
-						<UsersCount count={data.member_count} />
-					</div>
-
-					<a
-						href={data.invite_url || 'https://discord.gg/C6hEh2R4'}
-						target="_blank"
-						rel="noopener noreferrer"
-						className="block w-full transform rounded-md bg-gradient-to-r from-[#5865F2] to-[#4752C4] py-3 text-center font-medium text-white shadow-md transition-all duration-300 hover:scale-[1.02] hover:from-[#4752C4] hover:to-[#3a45a5]"
-					>
-						Join Server
-					</a>
-				</div>
-			</div>
-		</div>
-	);
-};
-
-const ErrorMessage = ({ msg }: { msg: string }) => (
-	<p className="text-red-500">Error loading Discord data: {msg}</p>
-);
-
-const Loader = () => (
-	<p className="text-gray-500 dark:text-gray-400">
-		Loading community information...
-	</p>
-);
-
-const UsersCount = ({ count }: { count: number }) => {
-	if (!count) return null;
-	return (
-		<div className="bg-green-500/20 flex items-center gap-1 rounded-full px-2 py-1 text-sm">
-			<Users className="h-4 w-4" />
-			<span className="text-center">{count} online</span>
-		</div>
+		<DiscordWidget
+			name={data.name || 'MeetJS Community'}
+			membersCount={data.member_count || 0}
+			inviteUrl={data.invite_url || DISCORD_INVITE_LINK}
+		/>
 	);
 };

--- a/src/components/DiscordCommunity.tsx
+++ b/src/components/DiscordCommunity.tsx
@@ -10,7 +10,7 @@ interface DiscordCommunityProps {
 	error?: string;
 }
 
-export const DiscordWidget = async () => {
+export const DiscordCommunity = async () => {
 	const { data, error } = await getDiscordServerData()
 		.then((data) => ({ data, error: null }))
 		.catch((e) => ({

--- a/src/components/DiscordCommunity.tsx
+++ b/src/components/DiscordCommunity.tsx
@@ -17,7 +17,7 @@ export const DiscordCommunity = async () => {
 			<div className="group relative mb-4 w-full max-w-md overflow-hidden rounded-lg bg-gradient-to-br from-[#2f3136] to-[#1e1f22] p-6 text-white shadow-xl transition-all duration-300 hover:shadow-2xl">
 				<div className="absolute inset-0 bg-gradient-to-r from-[#5865F2]/10 to-[#5865F2]/5 opacity-0 transition-opacity duration-300 group-hover:opacity-100"></div>
 
-				<div className="relative z-10">
+				<div className="relative">
 					<div className="mb-4 flex items-center justify-between">
 						<div>
 							<h4 className="text-lg font-bold">

--- a/src/components/DiscordCommunity.tsx
+++ b/src/components/DiscordCommunity.tsx
@@ -29,9 +29,7 @@ export const DiscordCommunity = async () => {
 							</p>
 						</div>
 
-						{data?.approximate_presence_count && (
-							<UsersCount count={data.approximate_member_count ?? 0} />
-						)}
+						<UsersCount count={data.member_count} />
 					</div>
 
 					<a
@@ -58,9 +56,12 @@ const Loader = () => (
 	</p>
 );
 
-const UsersCount = ({ count }: { count: number }) => (
-	<div className="bg-green-500/20 flex items-center gap-1 rounded-full px-2 py-1 text-sm">
-		<Users className="h-4 w-4" />
-		<span className="text-center">{count} online</span>
-	</div>
-);
+const UsersCount = ({ count }: { count: number }) => {
+	if (!count) return null;
+	return (
+		<div className="bg-green-500/20 flex items-center gap-1 rounded-full px-2 py-1 text-sm">
+			<Users className="h-4 w-4" />
+			<span className="text-center">{count} online</span>
+		</div>
+	);
+};

--- a/src/components/DiscordWidget.tsx
+++ b/src/components/DiscordWidget.tsx
@@ -1,0 +1,46 @@
+import { Users } from 'lucide-react';
+
+interface Props {
+	name: string;
+	membersCount: number;
+	inviteUrl: string;
+}
+
+export const DiscordWidget = ({ name, membersCount, inviteUrl }: Props) => (
+	<div className="flex flex-col items-center">
+		<div className="group relative mb-4 w-full max-w-md overflow-hidden rounded-lg bg-gradient-to-br from-[#2f3136] to-[#1e1f22] p-6 text-white shadow-xl transition-all duration-300 hover:shadow-2xl">
+			<div className="absolute inset-0 bg-gradient-to-r from-[#5865F2]/10 to-[#5865F2]/5 opacity-0 transition-opacity duration-300 group-hover:opacity-100"></div>
+
+			<div className="relative">
+				<div className="mb-4 flex items-center justify-between">
+					<div>
+						<h4 className="text-lg font-bold">{name}</h4>
+
+						<p className="mt-1 text-sm text-gray-300">
+							Connect with JavaScript developers
+						</p>
+					</div>
+
+					<UsersCount count={membersCount} />
+				</div>
+
+				<a
+					href={inviteUrl}
+					target="_blank"
+					rel="noopener noreferrer"
+					className="block w-full transform rounded-md bg-gradient-to-r from-[#5865F2] to-[#4752C4] py-3 text-center font-medium text-white shadow-md transition-all duration-300 hover:scale-[1.02] hover:from-[#4752C4] hover:to-[#3a45a5]"
+				>
+					Join Server
+				</a>
+			</div>
+		</div>
+	</div>
+);
+
+const UsersCount = ({ count }: { count: number }) =>
+	!count ? null : (
+		<div className="bg-green-500/20 flex items-center gap-1 rounded-full px-2 py-1 text-sm">
+			<Users className="h-4 w-4" />
+			<span className="text-center">{count} online</span>
+		</div>
+	);

--- a/src/components/JoinUs.tsx
+++ b/src/components/JoinUs.tsx
@@ -3,23 +3,10 @@ import { PolandMap } from './PolandMap';
 import { getUpcomingEvents } from '@/utils/getUpcomingEvents';
 import { Event } from '@/components/FeaturedEvents';
 import { MessagesSquare } from 'lucide-react';
-import { getDiscordServerData } from '@/lib/discord';
-import { DiscordCommunity } from './DiscordCommunity';
+import { DiscordWidget } from '@/components/DiscordCommunity';
 
 export const JoinUs = async () => {
 	const events: Event[] | null = await getUpcomingEvents();
-	let discordResponse: { data: Awaited<ReturnType<typeof getDiscordServerData>>, error?: string };
-
-	try {
-		discordResponse = {
-			data: await getDiscordServerData()
-		};
-	} catch (e) {
-		discordResponse = {
-			data: null,
-			error: e instanceof Error ? e.message : 'Failed to load Discord data'
-		};
-	}
 
 	return (
 		<section
@@ -51,15 +38,14 @@ export const JoinUs = async () => {
 						If you don&apos;t see your city on the map, consider starting a
 						local meet.js!
 					</p>
+
 					<div className="mt-4 border-t pt-6">
 						<h3 className="mb-4 flex items-center gap-2 text-xl font-semibold">
 							<MessagesSquare className="h-5 w-5 text-[#5865F2]" />
 							Join our Discord Community
 						</h3>
-						<DiscordCommunity 
-							discordData={discordResponse.data} 
-							error={discordResponse.error}
-						/>
+
+						<DiscordWidget />
 					</div>
 				</div>
 			</div>

--- a/src/components/JoinUs.tsx
+++ b/src/components/JoinUs.tsx
@@ -3,7 +3,7 @@ import { PolandMap } from './PolandMap';
 import { getUpcomingEvents } from '@/utils/getUpcomingEvents';
 import { Event } from '@/components/FeaturedEvents';
 import { MessagesSquare } from 'lucide-react';
-import { DiscordWidget } from '@/components/DiscordCommunity';
+import { DiscordCommunity } from '@/components/DiscordCommunity';
 
 export const JoinUs = async () => {
 	const events: Event[] | null = await getUpcomingEvents();
@@ -45,7 +45,7 @@ export const JoinUs = async () => {
 							Join our Discord Community
 						</h3>
 
-						<DiscordWidget />
+						<DiscordCommunity />
 					</div>
 				</div>
 			</div>

--- a/src/lib/discord.ts
+++ b/src/lib/discord.ts
@@ -1,11 +1,12 @@
 import { cache } from 'react';
 
+// https://discord.com/developers/docs/resources/guild#guild-widget-object
 interface DiscordWidgetData {
 	id: string; // Server ID
 	name: string; // Server name
 	instant_invite: string; // Invite URL
 	presence_count: number; // Online members count
-	members: DiscordMemeber[]; // Online members list
+	members: DiscordMemeber[];
 	channels: DiscordChannel[];
 }
 
@@ -25,19 +26,13 @@ interface DiscordChannel {
 }
 
 interface DiscordServerData {
-	approximate_presence_count?: number; // Online members
-	approximate_member_count?: number; // Total members
-	name?: string; // Server name
-	id?: string; // Server ID
-	invite_url?: string; // Invite URL
+	id: string;
+	name: string;
+	member_count: number;
+	invite_url: string;
 }
 
-/**
- * Gets Discord server information including member counts
- *
- * This implementation uses the Discord Widget API to get real-time data.
- * The widget is enabled for the meet.js server.
- */
+const ONE_HOUR = 3_600;
 export const getDiscordServerData = cache(
 	async (): Promise<DiscordServerData | null> => {
 		try {
@@ -45,11 +40,10 @@ export const getDiscordServerData = cache(
 
 			console.log('Fetching Discord widget data for server:', serverId);
 
-			// Use the Discord Widget API to get server information
 			const response = await fetch(
 				`https://discord.com/api/guilds/${serverId}/widget.json`,
 				{
-					next: { revalidate: 3600 }, // Cache for 1 hour
+					next: { revalidate: ONE_HOUR },
 				},
 			);
 
@@ -62,7 +56,7 @@ export const getDiscordServerData = cache(
 			return {
 				id: widgetData.id,
 				name: widgetData.name,
-				approximate_presence_count: widgetData.presence_count,
+				member_count: widgetData.presence_count,
 				invite_url: widgetData.instant_invite,
 			};
 		} catch (error) {

--- a/src/lib/discord.ts
+++ b/src/lib/discord.ts
@@ -1,30 +1,5 @@
 import { cache } from 'react';
 
-// https://discord.com/developers/docs/resources/guild#guild-widget-object
-interface DiscordWidgetData {
-	id: string; // Server ID
-	name: string; // Server name
-	instant_invite: string; // Invite URL
-	presence_count: number; // Online members count
-	members: DiscordMemeber[];
-	channels: DiscordChannel[];
-}
-
-interface DiscordMemeber {
-	id: string;
-	username: string;
-	status: string;
-	avatar?: string;
-	avatar_url?: string;
-	game?: { name: string };
-}
-
-interface DiscordChannel {
-	id: string;
-	name: string;
-	position: number;
-}
-
 interface DiscordServerData {
 	id: string;
 	name: string;
@@ -65,3 +40,28 @@ export const getDiscordServerData = cache(
 		}
 	},
 );
+
+// https://discord.com/developers/docs/resources/guild#guild-widget-object
+interface DiscordWidgetData {
+	id: string; // Server ID
+	name: string; // Server name
+	instant_invite: string; // Invite URL
+	presence_count: number; // Online members count
+	members: DiscordMemeber[];
+	channels: DiscordChannel[];
+}
+
+interface DiscordMemeber {
+	id: string;
+	username: string;
+	status: string;
+	avatar?: string;
+	avatar_url?: string;
+	game?: { name: string };
+}
+
+interface DiscordChannel {
+	id: string;
+	name: string;
+	position: number;
+}

--- a/src/lib/discord.ts
+++ b/src/lib/discord.ts
@@ -1,64 +1,73 @@
-import { cache } from 'react'
+import { cache } from 'react';
 
 interface DiscordWidgetData {
-  id: string;                // Server ID
-  name: string;              // Server name
-  instant_invite: string;    // Invite URL
-  presence_count: number;    // Online members count
-  members: Array<{           // Online members list
-    id: string;
-    username: string;
-    status: string;
-    avatar?: string;
-    avatar_url?: string;
-    game?: { name: string };
-  }>;
-  channels: Array<{
-    id: string;
-    name: string;
-    position: number;
-  }>;
+	id: string; // Server ID
+	name: string; // Server name
+	instant_invite: string; // Invite URL
+	presence_count: number; // Online members count
+	members: DiscordMemeber[]; // Online members list
+	channels: DiscordChannel[];
+}
+
+interface DiscordMemeber {
+	id: string;
+	username: string;
+	status: string;
+	avatar?: string;
+	avatar_url?: string;
+	game?: { name: string };
+}
+
+interface DiscordChannel {
+	id: string;
+	name: string;
+	position: number;
 }
 
 interface DiscordServerData {
-  approximate_presence_count?: number; // Online members
-  approximate_member_count?: number;   // Total members
-  name?: string;                       // Server name
-  id?: string;                         // Server ID
-  invite_url?: string;                 // Invite URL
+	approximate_presence_count?: number; // Online members
+	approximate_member_count?: number; // Total members
+	name?: string; // Server name
+	id?: string; // Server ID
+	invite_url?: string; // Invite URL
 }
 
 /**
  * Gets Discord server information including member counts
- * 
+ *
  * This implementation uses the Discord Widget API to get real-time data.
  * The widget is enabled for the meet.js server.
  */
-export const getDiscordServerData = cache(async (): Promise<DiscordServerData | null> => {
-  try {
-    const serverId = process.env.DISCORD_SERVER_ID;
-    
-    console.log('Fetching Discord widget data for server:', serverId);
-    
-    // Use the Discord Widget API to get server information
-    const response = await fetch(`https://discord.com/api/guilds/${serverId}/widget.json`, {
-      next: { revalidate: 3600 }, // Cache for 1 hour
-    });
-    
-    if (!response.ok) {
-      throw new Error(`Discord Widget API error: ${response.status}`);
-    }
-    
-    const widgetData: DiscordWidgetData = await response.json();
-    
-    return {
-      id: widgetData.id,
-      name: widgetData.name,
-      approximate_presence_count: widgetData.presence_count,
-      invite_url: widgetData.instant_invite,
-    };
-  } catch (error) {
-    console.error('Error fetching Discord server data:', error);
-    return null;
-  }
-});
+export const getDiscordServerData = cache(
+	async (): Promise<DiscordServerData | null> => {
+		try {
+			const serverId = process.env.DISCORD_SERVER_ID;
+
+			console.log('Fetching Discord widget data for server:', serverId);
+
+			// Use the Discord Widget API to get server information
+			const response = await fetch(
+				`https://discord.com/api/guilds/${serverId}/widget.json`,
+				{
+					next: { revalidate: 3600 }, // Cache for 1 hour
+				},
+			);
+
+			if (!response.ok) {
+				throw new Error(`Discord Widget API error: ${response.status}`);
+			}
+
+			const widgetData: DiscordWidgetData = await response.json();
+
+			return {
+				id: widgetData.id,
+				name: widgetData.name,
+				approximate_presence_count: widgetData.presence_count,
+				invite_url: widgetData.instant_invite,
+			};
+		} catch (error) {
+			console.error('Error fetching Discord server data:', error);
+			return null;
+		}
+	},
+);


### PR DESCRIPTION
## Merging to https://github.com/naugtur/meetjs.pl/pull/149
- Removed duplicate labels (error & loading state)
- Moved the loading of data into the Discord Widget & simplified data flow
- Fixed the z-index bug causing overlap of the widget with website navigation bar
- Adjusted mapping of Discord API response
- Conditionally display Users Count (hide for `0` online users)
- Code formatting (prettier)

## Proposition

**In case of API error just display a static fallback without user count**.
`name` & `invite link` (link can expire) could be static, online user count can be hidden

![image](https://github.com/user-attachments/assets/7bc49f6a-676f-4a53-9329-c6b8e5023e91)
