### PR TITLE
feat: Analytics - track events for clicking discord invite

### DIFF
--- a/src/components/DiscordInviteLink.tsx
+++ b/src/components/DiscordInviteLink.tsx
@@ -1,0 +1,20 @@
+'use client';
+import { trackClientEvent } from '@/lib/analytics';
+
+interface Props {
+	href: string;
+}
+
+const trackDiscordInviteClick = () => trackClientEvent('click_discord_invite');
+
+export const DiscordInviteLink = ({ href }: Props) => (
+	<a
+		onClick={trackDiscordInviteClick}
+		href={href}
+		target="_blank"
+		rel="noopener noreferrer"
+		className="block w-full transform rounded-md bg-gradient-to-r from-[#5865F2] to-[#4752C4] py-3 text-center font-medium text-white shadow-md transition-all duration-300 hover:scale-[1.02] hover:from-[#4752C4] hover:to-[#3a45a5]"
+	>
+		Join Server
+	</a>
+);

--- a/src/components/DiscordWidget.tsx
+++ b/src/components/DiscordWidget.tsx
@@ -1,4 +1,5 @@
 import { Users } from 'lucide-react';
+import { DiscordInviteLink } from './DiscordInviteLink';
 
 interface Props {
 	name: string;
@@ -24,14 +25,7 @@ export const DiscordWidget = ({ name, membersCount, inviteUrl }: Props) => (
 					<UsersCount count={membersCount} />
 				</div>
 
-				<a
-					href={inviteUrl}
-					target="_blank"
-					rel="noopener noreferrer"
-					className="block w-full transform rounded-md bg-gradient-to-r from-[#5865F2] to-[#4752C4] py-3 text-center font-medium text-white shadow-md transition-all duration-300 hover:scale-[1.02] hover:from-[#4752C4] hover:to-[#3a45a5]"
-				>
-					Join Server
-				</a>
+				<DiscordInviteLink href={inviteUrl} />
 			</div>
 		</div>
 	</div>

--- a/src/lib/analytics.ts
+++ b/src/lib/analytics.ts
@@ -1,0 +1,11 @@
+import { track } from '@vercel/analytics';
+
+type AnalyticsClientEvent = 'click_discord_invite';
+
+type TrackClientEvent = (
+	event: AnalyticsClientEvent,
+	properties?: Parameters<typeof track>[1],
+	options?: Parameters<typeof track>[2],
+) => void;
+
+export const trackClientEvent: TrackClientEvent = (...args) => track(...args);


### PR DESCRIPTION
We want to track Discord invite link clicks for attempting joining our Discord Community Server 📊 

> There are 2 different functions for tracking client & server events. This implements client side only.
https://vercel.com/docs/analytics/custom-events