### PR TITLE
feat: add split city markers for locations with additional events and remove TypeScript status

### DIFF
--- a/src/components/JoinUs.tsx
+++ b/src/components/JoinUs.tsx
@@ -4,9 +4,11 @@ import { getUpcomingEvents } from '@/utils/getUpcomingEvents';
 import { Event } from '@/components/FeaturedEvents';
 import { MessagesSquare } from 'lucide-react';
 import { DiscordCommunity } from '@/components/DiscordCommunity';
+import { ADDITIONAL_EVENTS } from '@/content/additionalEvents';
 
 export const JoinUs = async () => {
-  const events: Event[] | null = await getUpcomingEvents();
+  const apiEvents: Event[] | null = await getUpcomingEvents();
+  const allEvents: Event[] = [...(apiEvents || []), ...ADDITIONAL_EVENTS];
 
   return (
     <section
@@ -19,7 +21,7 @@ export const JoinUs = async () => {
 
       <div className="mx-auto flex w-full max-w-7xl flex-col p-4 md:flex-row">
         <div className="w-full md:w-1/2">
-          <PolandMap cities={CITIES} events={events ?? []} />
+          <PolandMap cities={CITIES} events={allEvents} />
         </div>
         <div className="w-full p-4 md:w-1/2">
           <p className="pb-6">

--- a/src/components/PolandMap.tsx
+++ b/src/components/PolandMap.tsx
@@ -9,14 +9,12 @@ type MapProps = {
 
 function getCityFillColor(status: City['status']): string {
   switch (status) {
-    case 'typescript':
-      return '#2563eb';
     case 'active':
+    case 'new':
       return '#219eab';
     case 'coming-soon':
       return '#EAB308';
-    case 'new':
-      return '#219eab';
+    case 'paused':
     default:
       return '#9CA3AF';
   }
@@ -25,10 +23,10 @@ function getCityFillColor(status: City['status']): string {
 function getCityTextFillColor(status: City['status']): string {
   switch (status) {
     case 'active':
-    case 'typescript':
     case 'coming-soon':
     case 'new':
       return '#2b1932';
+    case 'paused':
     default:
       return '#6B7280';
   }
@@ -77,14 +75,34 @@ export const PolandMap = ({ cities, events = [] }: MapProps) => {
               <g key={index}>
                 <Link href={city.href}>
                   <g className="city-marker group">
-                    {/* City dot */}
-                    <circle
-                      cx={city.pointPosition.x}
-                      cy={city.pointPosition.y}
-                      r="3"
-                      fill={getCityFillColor(city.status)}
-                      className="cursor-pointer hover:opacity-80"
-                    />
+                    {/* City dot - split if has additional events */}
+                    {eventStatus !== 'none' ? (
+                      <foreignObject
+                        x={city.pointPosition.x - 3}
+                        y={city.pointPosition.y - 3}
+                        width="6"
+                        height="6"
+                        className="cursor-pointer hover:opacity-80"
+                      >
+                        <div className="flex h-[6px] w-[6px]">
+                          <div
+                            className="h-[6px] w-[3px] rounded-l-full"
+                            style={{
+                              backgroundColor: getCityFillColor(city.status),
+                            }}
+                          />
+                          <div className="h-[6px] w-[3px] rounded-r-full bg-[#9333ea]" />
+                        </div>
+                      </foreignObject>
+                    ) : (
+                      <circle
+                        cx={city.pointPosition.x}
+                        cy={city.pointPosition.y}
+                        r="3"
+                        fill={getCityFillColor(city.status)}
+                        className="cursor-pointer hover:opacity-80"
+                      />
+                    )}
 
                     {/* Event status circle */}
                     {eventStatus !== 'none' && (
@@ -144,15 +162,14 @@ export const PolandMap = ({ cities, events = [] }: MapProps) => {
               <div className="absolute -inset-1 rounded-full border border-[#219eab]" />
             </div>
             <div className="relative">
-              <div className="h-2 w-2 rounded-full bg-[#219eab]" />
+              <div className="flex h-2 w-2">
+                <div className="h-2 w-1 rounded-l-full bg-[#219eab]" />
+                <div className="h-2 w-1 rounded-r-full bg-[#9333ea]" />
+              </div>
               <div className="absolute -inset-1 animate-pulse rounded-full border-2 border-[#9333ea] dark:border-green-500" />
             </div>
           </div>
-          <span>Active / upcoming / in progress</span>
-        </div>
-        <div className="flex items-center gap-2 whitespace-nowrap">
-          <div className="h-2 w-2 rounded-full bg-[#2563eb]" />
-          <span>TypeScript Gdańsk</span>
+          <span>Active / with upcoming / with in-progress events</span>
         </div>
         <div className="flex items-center gap-2 whitespace-nowrap">
           <div className="relative">

--- a/src/content/additionalEvents.ts
+++ b/src/content/additionalEvents.ts
@@ -19,4 +19,19 @@ export const ADDITIONAL_EVENTS: Event[] = [
     serie: 'TypeScript',
     topic: ['TypeScript', 'JavaScript'],
   },
+  {
+    type: 'Meetup',
+    id: 99999, // unique id
+    date_add: Date.now(),
+    date: '02.09.2025',
+    time: '18:00',
+    name: 'AI Meetup in Wroclaw with Callstack & Vercel',
+    url: 'https://www.callstack.com/events/ai-meetup-in-wroclaw-first-edition',
+    rsvp: 'https://www.callstack.com/events/ai-meetup-in-wroclaw-first-edition',
+    city: 'Wrocław',
+    address: 'Concordia Design',
+    image: '',
+    serie: 'AI',
+    topic: ['AI', 'React Native', 'JavaScript', 'React'],
+  },
 ];

--- a/src/content/cities.tsx
+++ b/src/content/cities.tsx
@@ -9,7 +9,7 @@ export interface City {
     x: number;
     y: number;
   };
-  status: 'active' | 'paused' | 'coming-soon' | 'new' | 'typescript'; // added 'typescript'
+  status: 'active' | 'paused' | 'coming-soon' | 'new';
 }
 
 export const CITIES: City[] = [
@@ -39,7 +39,6 @@ export const CITIES: City[] = [
     },
     status: 'active',
   },
-  // Special marker for TypeScript Gdańsk event
   {
     name: 'Gdańsk',
     href: '/gdansk',
@@ -51,7 +50,7 @@ export const CITIES: City[] = [
       x: 70,
       y: 34,
     },
-    status: 'typescript', // blue marker for TypeScript event
+    status: 'active',
   },
   {
     name: 'Katowice',


### PR DESCRIPTION
<img width="963" height="846" alt="Screenshot 2025-08-22 at 15 08 12" src="https://github.com/user-attachments/assets/635fe87c-dea5-4cbd-945c-01696022862b" />
<img width="794" height="733" alt="Screenshot 2025-08-22 at 15 08 08" src="https://github.com/user-attachments/assets/73f13753-0851-4671-8f9d-66a8c72f4c44" />
