### PR TITLE
feat: add FutureConf 2025 event to additional events list

### DIFF
--- a/src/content/additionalEvents.ts
+++ b/src/content/additionalEvents.ts
@@ -34,4 +34,19 @@ export const ADDITIONAL_EVENTS: Event[] = [
     serie: 'AI',
     topic: ['AI', 'React Native', 'JavaScript', 'React'],
   },
+  {
+    type: 'Conference',
+    id: 100000, // unique id
+    date_add: Date.now(),
+    date: '27.10.2025',
+    time: '8:30',
+    name: 'FutureConf 2025',
+    url: 'https://futureconf.tech/',
+    rsvp: 'https://futureconf.tech/',
+    city: 'Kraków',
+    address: 'Międzynarodowe Centrum Kultury\nRynek Główny 25',
+    image: '',
+    serie: 'AI & Future Tech',
+    topic: ['AI', 'Machine Learning', 'JavaScript', 'Future Technologies'],
+  },
 ];


### PR DESCRIPTION
<img width="706" height="486" alt="Screenshot 2025-08-28 at 01 19 41" src="https://github.com/user-attachments/assets/f7ac193f-ee5d-4d7d-bf2e-d9ba6acfb408" />

<img width="1034" height="723" alt="Screenshot 2025-08-28 at 01 19 47" src="https://github.com/user-attachments/assets/c522090f-912b-43d4-ba2d-8254f0936353" />

