### PR TITLE
feat: add support for custom text colors and image icons in promo banners

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -35,6 +35,10 @@ const nextConfig: NextConfig = {
         protocol: 'https',
         hostname: 'futureconf.tech',
       },
+      {
+        protocol: 'https',
+        hostname: 'piccalil.li',
+      },
     ],
   },
   pageExtensions: ['js', 'jsx', 'ts', 'tsx', 'md', 'mdx'],

--- a/src/components/PromoBanners.tsx
+++ b/src/components/PromoBanners.tsx
@@ -89,11 +89,14 @@ export const PromoBanners = ({ promos }: Props) => {
   return <PromoBanner promo={promo} close={() => handleClose(promo.id)} />;
 };
 
-const PromoBanner = ({ promo, close }: { promo: Promo; close: () => void }) => (
-  <div className="relative">
-    <div
-      className={`relative ${promo.gradient || 'bg-gradient-to-r from-blue via-purple to-green'} animate-fade-in z-0 py-1.5 text-white shadow md:py-2`}
-    >
+const PromoBanner = ({ promo, close }: { promo: Promo; close: () => void }) => {
+  const textColor = promo.textColor || 'text-white';
+  
+  return (
+    <div className="relative">
+      <div
+        className={`relative ${promo.gradient || 'bg-gradient-to-r from-blue via-purple to-green'} animate-fade-in z-0 py-1.5 shadow md:py-2 ${textColor}`}
+      >
       <div className="mx-2 sm:mx-4">
         <div className="flex flex-col items-center justify-between gap-1 text-center md:flex-row md:gap-2 md:text-left">
           <div className="hidden md:block">
@@ -107,22 +110,35 @@ const PromoBanner = ({ promo, close }: { promo: Promo; close: () => void }) => (
 
           <div className="flex items-center gap-2">
             <LinkCTA ticketLink={promo.ticketLink}>{promo.cta}</LinkCTA>
-            <CloseButton close={close} />
+            <CloseButton close={close} textColor={textColor} />
           </div>
         </div>
       </div>
     </div>
   </div>
-);
+  );
+};
 
 const Icon = ({
   icon,
   emojiLeft,
 }: {
-  icon?: React.ReactNode;
+  icon?: React.ReactNode | string;
   emojiLeft?: string;
 }) => {
-  if (icon) return <span className="mr-2 text-xl md:text-2xl">{icon}</span>;
+  if (icon) {
+    // Check if icon is a string URL
+    if (typeof icon === 'string' && (icon.startsWith('http://') || icon.startsWith('https://'))) {
+      return (
+        <img 
+          src={icon} 
+          alt="Icon" 
+          className="mr-2 h-5 w-5 md:h-6 md:w-6 object-contain"
+        />
+      );
+    }
+    return <span className="mr-2 text-xl md:text-2xl">{icon}</span>;
+  }
 
   if (emojiLeft) {
     return (
@@ -169,12 +185,17 @@ const LinkCTA = ({
   )
 );
 
-const CloseButton = ({ close }: { close: () => void }) => (
-  <button
-    onClick={close}
-    aria-label="Dismiss promo banner"
-    className="absolute right-4 top-2 text-white hover:text-gray-200 focus:outline-none md:static md:right-auto md:top-auto"
-  >
-    <X className="h-6 w-6" />
-  </button>
-);
+const CloseButton = ({ close, textColor }: { close: () => void; textColor: string }) => {
+  // Derive hover color based on text color
+  const hoverColor = textColor === 'text-white' ? 'hover:text-gray-200' : 'hover:opacity-70';
+  
+  return (
+    <button
+      onClick={close}
+      aria-label="Dismiss promo banner"
+      className={`absolute right-4 top-2 focus:outline-none md:static md:right-auto md:top-auto ${textColor} ${hoverColor}`}
+    >
+      <X className="h-6 w-6" />
+    </button>
+  );
+};

--- a/src/components/UnifiedPromoCard.tsx
+++ b/src/components/UnifiedPromoCard.tsx
@@ -31,6 +31,7 @@ interface VariantConfig {
   defaultIcon: string;
   discountVariant: 'event' | 'software';
   ctaGradient: string;
+  ctaTextColor?: string;
   linkColor: string;
   websiteLabel: string;
 }
@@ -57,6 +58,7 @@ const variantConfigs: Record<PromoVariant, VariantConfig> = {
     defaultIcon: '📚',
     discountVariant: 'software',
     ctaGradient: 'bg-gradient-to-r from-green-600 to-teal-600 hover:from-green-700 hover:to-teal-700',
+    ctaTextColor: 'text-white',
     linkColor: 'text-green-600 hover:text-green-700 dark:text-green-400 dark:hover:text-green-300',
     websiteLabel: 'Course Website',
   },
@@ -73,6 +75,10 @@ export default function UnifiedPromoCard({
 }: UnifiedPromoCardProps) {
   const config = variantConfigs[variant];
   const isEventVariant = variant === 'event';
+  
+  // Use promo-specific gradient and text color if provided, otherwise use variant defaults
+  const ctaGradient = promo.gradient || config.ctaGradient;
+  const ctaTextColor = promo.textColor || config.ctaTextColor || 'text-white';
   
   return (
     <div className="group relative overflow-hidden rounded-xl border border-gray-200 bg-white shadow-lg transition-all duration-300 hover:-translate-y-1 hover:shadow-xl dark:border-gray-700 dark:bg-gray-800">
@@ -215,12 +221,12 @@ export default function UnifiedPromoCard({
             href={promo.ticketLink}
             target="_blank"
             rel="noopener noreferrer"
-            className={`block w-full rounded-lg py-3 text-center font-semibold text-white shadow transition-all hover:shadow-lg ${config.ctaGradient}`}
+            className={`block w-full rounded-lg py-3 text-center font-semibold shadow transition-all hover:shadow-lg ${ctaTextColor} ${ctaGradient}`}
           >
             {promo.cta}
           </a>
         ) : (
-          <span className={`block w-full rounded-lg py-3 text-center font-semibold text-white/80 shadow ${config.ctaGradient} opacity-60`}>
+          <span className={`block w-full rounded-lg py-3 text-center font-semibold shadow opacity-60 ${ctaTextColor}/80 ${ctaGradient}`}>
             {promo.cta}
           </span>
         )}

--- a/src/content/learning-discounts.ts
+++ b/src/content/learning-discounts.ts
@@ -33,4 +33,21 @@ export const learningDiscounts: Promo[] = [
     emojiRight: '🌐',
     discountCode: 'MEETJS',
   },
+  {
+    id: 'piccalilli-2025',
+    name: 'Piccalilli',
+    message: '40% off all courses with code MEETJS!',
+    cta: '📚 Get 40% Off',
+    ticketLink: 'https://piccalil.li/courses/',
+    eventLink: 'https://piccalil.li',
+    expiresAt: '2025-12-31T23:59:59+02:00',
+    description:
+      'Get 40% off all Piccalilli courses with code MEETJS! Learn modern CSS, accessibility, progressive enhancement, and web performance from industry experts. Piccalilli also offers automatic 40% PPP (Purchasing Power Parity) discounts for developers in Poland. Perfect for frontend developers who want to build better, more accessible websites.',
+    gradient: 'bg-gradient-to-r from-yellow-400 via-amber-500 to-orange-500',
+    textColor: 'text-gray-900',
+    image: 'https://piccalil.li/favicons/favicon-32x32.png',
+    icon: 'https://piccalil.li/favicons/favicon-32x32.png',
+    emojiRight: '✨',
+    discountCode: 'MEETJS',
+  },
 ];

--- a/src/types/promo.ts
+++ b/src/types/promo.ts
@@ -12,9 +12,10 @@ export interface Promo {
   city?: string;
   emojiRight?: string;
   emojiLeft?: string;
-  icon?: ReactNode;
+  icon?: ReactNode | string;
   image?: string;
   gradient: string;
+  textColor?: string;
   cta: string;
   discountCode?: string;
   workshopLink?: string;


### PR DESCRIPTION
<img width="606" height="760" alt="Screenshot 2025-10-16 at 11 46 11" src="https://github.com/user-attachments/assets/d433d516-f06b-404b-a892-0b788eefdce2" />
<img width="596" height="255" alt="Screenshot 2025-10-16 at 11 46 06" src="https://github.com/user-attachments/assets/5017f8af-765f-4faa-9bbf-53243abf8e34" />
