### PR TITLE
feat: simplify favicon configuration

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -56,13 +56,7 @@ export const metadata: Metadata = {
   icons: {
     icon: '/favicon.ico',
     shortcut: '/favicon.ico',
-    apple: '/apple-touch-icon.png',
-    other: [
-      {
-        rel: 'apple-touch-icon-precomposed',
-        url: '/apple-touch-icon-precomposed.png',
-      },
-    ],
+    apple: '/favicon.ico',
   },
   openGraph: {
     title: 'meet.js - JavaScript Meetups in Poland',


### PR DESCRIPTION
- Consolidated all favicon references to use single /favicon.ico file instead of separate Apple touch icons
- Removed unused apple-touch-icon-precomposed configuration
- Updated Apple touch icon to use same favicon for consistent branding across platforms