### PR TITLE
refactor: remove jiti dependency and simplify config loading

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,12 +1,7 @@
 import { fileURLToPath } from 'node:url';
-import createJiti from 'jiti';
 
 import createMDX from '@next/mdx';
 import { NextConfig } from 'next';
-
-const jiti = createJiti(fileURLToPath(import.meta.url));
-
-jiti('./src/env.ts');
 
 /** @type {import('next').NextConfig} */
 const nextConfig: NextConfig = {

--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react-hooks": "^7.0.0",
     "husky": "^9.1.4",
-    "jiti": "^1.21.6",
     "jsdom": "^26.1.0",
     "lint-staged": "^15.2.9",
     "postcss": "^8.4.41",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,7 +108,7 @@ importers:
         version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@tolgee/cli':
         specifier: ^2.14.0
-        version: 2.14.0(jiti@1.21.6)(typescript@5.8.3)
+        version: 2.14.0(jiti@2.6.1)(typescript@5.8.3)
       '@types/mdx':
         specifier: ^2.0.13
         version: 2.0.13
@@ -123,28 +123,25 @@ importers:
         version: 19.2.2(@types/react@19.2.2)
       '@vitejs/plugin-react':
         specifier: ^4.4.0
-        version: 4.4.0(vite@6.4.1(@types/node@22.3.0)(jiti@1.21.6)(terser@5.39.0)(tsx@4.19.4)(yaml@2.5.0))
+        version: 4.4.0(vite@6.4.1(@types/node@22.3.0)(jiti@2.6.1)(terser@5.39.0)(tsx@4.19.4)(yaml@2.5.0))
       babel-plugin-react-compiler:
         specifier: 19.1.0-rc.2
         version: 19.1.0-rc.2
       eslint:
         specifier: 9.31.0
-        version: 9.31.0(jiti@1.21.6)
+        version: 9.31.0(jiti@2.6.1)
       eslint-config-next:
         specifier: 16.0.0
-        version: 16.0.0(@typescript-eslint/parser@8.46.0(eslint@9.31.0(jiti@1.21.6))(typescript@5.8.3))(eslint@9.31.0(jiti@1.21.6))(typescript@5.8.3)
+        version: 16.0.0(@typescript-eslint/parser@8.46.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3)
       eslint-config-prettier:
         specifier: ^10.1.8
-        version: 10.1.8(eslint@9.31.0(jiti@1.21.6))
+        version: 10.1.8(eslint@9.31.0(jiti@2.6.1))
       eslint-plugin-react-hooks:
         specifier: ^7.0.0
-        version: 7.0.0(eslint@9.31.0(jiti@1.21.6))
+        version: 7.0.0(eslint@9.31.0(jiti@2.6.1))
       husky:
         specifier: ^9.1.4
         version: 9.1.4
-      jiti:
-        specifier: ^1.21.6
-        version: 1.21.6
       jsdom:
         specifier: ^26.1.0
         version: 26.1.0
@@ -168,10 +165,10 @@ importers:
         version: 5.8.3
       typescript-eslint:
         specifier: ^8.46.0
-        version: 8.46.0(eslint@9.31.0(jiti@1.21.6))(typescript@5.8.3)
+        version: 8.46.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3)
       vitest:
         specifier: ^3.1.1
-        version: 3.1.1(@types/debug@4.1.12)(@types/node@22.3.0)(jiti@1.21.6)(jsdom@26.1.0)(terser@5.39.0)(tsx@4.19.4)(yaml@2.5.0)
+        version: 3.1.1(@types/debug@4.1.12)(@types/node@22.3.0)(jiti@2.6.1)(jsdom@26.1.0)(terser@5.39.0)(tsx@4.19.4)(yaml@2.5.0)
 
 packages:
 
@@ -1564,8 +1561,8 @@ packages:
   '@types/ms@0.7.34':
     resolution: {integrity: sha512-nG96G3Wp6acyAgJqGasjODb+acrI7KltPiRxzHPXnP3NgI28bpQDRv53olbqGXbfcgF5aiiHmO3xpwEpS5Ld9g==}
 
-  '@types/node@22.18.12':
-    resolution: {integrity: sha512-BICHQ67iqxQGFSzfCFTT7MRQ5XcBjG5aeKh5Ok38UBbPe5fxTyE+aHFxwVrGyr8GNlqFMLKD1D3P2K/1ks8tog==}
+  '@types/node@22.18.13':
+    resolution: {integrity: sha512-Bo45YKIjnmFtv6I1TuC8AaHBbqXtIo+Om5fE4QiU1Tj8QR/qt+8O3BAtOimG5IFmwaWiPmB3Mv3jtYzBA4Us2A==}
 
   '@types/node@22.3.0':
     resolution: {integrity: sha512-nrWpWVaDZuaVc5X84xJ0vNrLvomM205oQyLsRt7OHNZbSHslcWsvgFR7O7hire2ZonjLrWBbedmotmIlJDVd6g==}
@@ -1962,8 +1959,8 @@ packages:
   base32-decode@1.0.0:
     resolution: {integrity: sha512-KNWUX/R7wKenwE/G/qFMzGScOgVntOmbE27vvc6GrniDGYb6a5+qWcuoXl8WIOQL7q0TpK7nZDm1Y04Yi3Yn5g==}
 
-  baseline-browser-mapping@2.8.19:
-    resolution: {integrity: sha512-zoKGUdu6vb2jd3YOq0nnhEDQVbPcHhco3UImJrv5dSkvxTc2pl2WjOPsjZXDwPDSl5eghIMuY3R6J9NDKF3KcQ==}
+  baseline-browser-mapping@2.8.21:
+    resolution: {integrity: sha512-JU0h5APyQNsHOlAM7HnQnPToSDQoEBZqzu/YBlqDnEeymPnZDREeXJA3KBMQee+dKteAxZ2AtvQEvVYdZf241Q==}
     hasBin: true
 
   binary-extensions@2.3.0:
@@ -2281,8 +2278,8 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
-  electron-to-chromium@1.5.238:
-    resolution: {integrity: sha512-khBdc+w/Gv+cS8e/Pbnaw/FXcBUeKrRVik9IxfXtgREOWyJhR4tj43n3amkVogJ/yeQUqzkrZcFhtIxIdqmmcQ==}
+  electron-to-chromium@1.5.243:
+    resolution: {integrity: sha512-ZCphxFW3Q1TVhcgS9blfut1PX8lusVi2SvXQgmEEnK4TCmE1JhH2JkjJN+DNt0pJJwfBri5AROBnz2b/C+YU9g==}
 
   electron-to-chromium@1.5.88:
     resolution: {integrity: sha512-K3C2qf1o+bGzbilTDCTBhTQcMS9KW60yTAaTeeXsfvQuTDDwlokLam/AdqlqcSy9u4UainDgsHV23ksXAOgamw==}
@@ -3106,8 +3103,12 @@ packages:
     resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
     engines: {node: '>= 10.13.0'}
 
-  jiti@1.21.6:
-    resolution: {integrity: sha512-2yTgeWTWzMWkHu6Jp9NKgePDaYHbntiwvYuuJLbbN9vl7DC9DvXKOB2BC3ZZ92D3cvV/aflH0osDfwpHepQ53w==}
+  jiti@1.21.7:
+    resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
+    hasBin: true
+
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
   js-tokens@4.0.0:
@@ -3475,8 +3476,8 @@ packages:
   node-releases@2.0.19:
     resolution: {integrity: sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==}
 
-  node-releases@2.0.26:
-    resolution: {integrity: sha512-S2M9YimhSjBSvYnlr5/+umAnPHE++ODwt5e2Ij6FoX45HA/s4vHdkDx1eax2pAPeAOqu4s9b7ppahsyEFdVqQA==}
+  node-releases@2.0.27:
+    resolution: {integrity: sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==}
 
   normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
@@ -4995,14 +4996,14 @@ snapshots:
   '@esbuild/win32-x64@0.25.2':
     optional: true
 
-  '@eslint-community/eslint-utils@4.4.0(eslint@9.31.0(jiti@1.21.6))':
+  '@eslint-community/eslint-utils@4.4.0(eslint@9.31.0(jiti@2.6.1))':
     dependencies:
-      eslint: 9.31.0(jiti@1.21.6)
+      eslint: 9.31.0(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
-  '@eslint-community/eslint-utils@4.9.0(eslint@9.31.0(jiti@1.21.6))':
+  '@eslint-community/eslint-utils@4.9.0(eslint@9.31.0(jiti@2.6.1))':
     dependencies:
-      eslint: 9.31.0(jiti@1.21.6)
+      eslint: 9.31.0(jiti@2.6.1)
       eslint-visitor-keys: 3.4.3
 
   '@eslint-community/regexpp@4.12.1': {}
@@ -5764,7 +5765,7 @@ snapshots:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.2(@types/react@19.2.2)
 
-  '@tolgee/cli@2.14.0(jiti@1.21.6)(typescript@5.8.3)':
+  '@tolgee/cli@2.14.0(jiti@2.6.1)(typescript@5.8.3)':
     dependencies:
       ajv: 8.17.1
       ansi-colors: 4.1.3
@@ -5780,7 +5781,7 @@ snapshots:
       vscode-textmate: 9.2.1
       yauzl: 3.2.0
     optionalDependencies:
-      jiti: 1.21.6
+      jiti: 2.6.1
     transitivePeerDependencies:
       - typescript
 
@@ -5862,7 +5863,7 @@ snapshots:
 
   '@types/ms@0.7.34': {}
 
-  '@types/node@22.18.12':
+  '@types/node@22.18.13':
     dependencies:
       undici-types: 6.21.0
     optional: true
@@ -5883,15 +5884,15 @@ snapshots:
 
   '@types/unist@3.0.2': {}
 
-  '@typescript-eslint/eslint-plugin@8.46.0(@typescript-eslint/parser@8.46.0(eslint@9.31.0(jiti@1.21.6))(typescript@5.8.3))(eslint@9.31.0(jiti@1.21.6))(typescript@5.8.3)':
+  '@typescript-eslint/eslint-plugin@8.46.0(@typescript-eslint/parser@8.46.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3)':
     dependencies:
       '@eslint-community/regexpp': 4.12.1
-      '@typescript-eslint/parser': 8.46.0(eslint@9.31.0(jiti@1.21.6))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.46.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3)
       '@typescript-eslint/scope-manager': 8.46.0
-      '@typescript-eslint/type-utils': 8.46.0(eslint@9.31.0(jiti@1.21.6))(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.46.0(eslint@9.31.0(jiti@1.21.6))(typescript@5.8.3)
+      '@typescript-eslint/type-utils': 8.46.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.46.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.46.0
-      eslint: 9.31.0(jiti@1.21.6)
+      eslint: 9.31.0(jiti@2.6.1)
       graphemer: 1.4.0
       ignore: 7.0.5
       natural-compare: 1.4.0
@@ -5900,14 +5901,14 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/parser@8.46.0(eslint@9.31.0(jiti@1.21.6))(typescript@5.8.3)':
+  '@typescript-eslint/parser@8.46.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 8.46.0
       '@typescript-eslint/types': 8.46.0
       '@typescript-eslint/typescript-estree': 8.46.0(typescript@5.8.3)
       '@typescript-eslint/visitor-keys': 8.46.0
       debug: 4.4.0
-      eslint: 9.31.0(jiti@1.21.6)
+      eslint: 9.31.0(jiti@2.6.1)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -5930,13 +5931,13 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
-  '@typescript-eslint/type-utils@8.46.0(eslint@9.31.0(jiti@1.21.6))(typescript@5.8.3)':
+  '@typescript-eslint/type-utils@8.46.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3)':
     dependencies:
       '@typescript-eslint/types': 8.46.0
       '@typescript-eslint/typescript-estree': 8.46.0(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.46.0(eslint@9.31.0(jiti@1.21.6))(typescript@5.8.3)
+      '@typescript-eslint/utils': 8.46.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3)
       debug: 4.4.0
-      eslint: 9.31.0(jiti@1.21.6)
+      eslint: 9.31.0(jiti@2.6.1)
       ts-api-utils: 2.1.0(typescript@5.8.3)
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -5960,13 +5961,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.46.0(eslint@9.31.0(jiti@1.21.6))(typescript@5.8.3)':
+  '@typescript-eslint/utils@8.46.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.0(eslint@9.31.0(jiti@1.21.6))
+      '@eslint-community/eslint-utils': 4.9.0(eslint@9.31.0(jiti@2.6.1))
       '@typescript-eslint/scope-manager': 8.46.0
       '@typescript-eslint/types': 8.46.0
       '@typescript-eslint/typescript-estree': 8.46.0(typescript@5.8.3)
-      eslint: 9.31.0(jiti@1.21.6)
+      eslint: 9.31.0(jiti@2.6.1)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -5988,14 +5989,14 @@ snapshots:
       next: 16.0.0(@babel/core@7.26.10)(babel-plugin-react-compiler@19.1.0-rc.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
 
-  '@vitejs/plugin-react@4.4.0(vite@6.4.1(@types/node@22.3.0)(jiti@1.21.6)(terser@5.39.0)(tsx@4.19.4)(yaml@2.5.0))':
+  '@vitejs/plugin-react@4.4.0(vite@6.4.1(@types/node@22.3.0)(jiti@2.6.1)(terser@5.39.0)(tsx@4.19.4)(yaml@2.5.0))':
     dependencies:
       '@babel/core': 7.26.10
       '@babel/plugin-transform-react-jsx-self': 7.25.9(@babel/core@7.26.10)
       '@babel/plugin-transform-react-jsx-source': 7.25.9(@babel/core@7.26.10)
       '@types/babel__core': 7.20.5
       react-refresh: 0.17.0
-      vite: 6.4.1(@types/node@22.3.0)(jiti@1.21.6)(terser@5.39.0)(tsx@4.19.4)(yaml@2.5.0)
+      vite: 6.4.1(@types/node@22.3.0)(jiti@2.6.1)(terser@5.39.0)(tsx@4.19.4)(yaml@2.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -6006,13 +6007,13 @@ snapshots:
       chai: 5.2.0
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.1.1(vite@6.4.1(@types/node@22.3.0)(jiti@1.21.6)(terser@5.39.0)(tsx@4.19.4)(yaml@2.5.0))':
+  '@vitest/mocker@3.1.1(vite@6.4.1(@types/node@22.3.0)(jiti@2.6.1)(terser@5.39.0)(tsx@4.19.4)(yaml@2.5.0))':
     dependencies:
       '@vitest/spy': 3.1.1
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 6.4.1(@types/node@22.3.0)(jiti@1.21.6)(terser@5.39.0)(tsx@4.19.4)(yaml@2.5.0)
+      vite: 6.4.1(@types/node@22.3.0)(jiti@2.6.1)(terser@5.39.0)(tsx@4.19.4)(yaml@2.5.0)
 
   '@vitest/pretty-format@3.1.1':
     dependencies:
@@ -6350,7 +6351,7 @@ snapshots:
 
   base32-decode@1.0.0: {}
 
-  baseline-browser-mapping@2.8.19:
+  baseline-browser-mapping@2.8.21:
     optional: true
 
   binary-extensions@2.3.0: {}
@@ -6377,10 +6378,10 @@ snapshots:
 
   browserslist@4.27.0:
     dependencies:
-      baseline-browser-mapping: 2.8.19
+      baseline-browser-mapping: 2.8.21
       caniuse-lite: 1.0.30001751
-      electron-to-chromium: 1.5.238
-      node-releases: 2.0.26
+      electron-to-chromium: 1.5.243
+      node-releases: 2.0.27
       update-browserslist-db: 1.1.4(browserslist@4.27.0)
     optional: true
 
@@ -6673,7 +6674,7 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
-  electron-to-chromium@1.5.238:
+  electron-to-chromium@1.5.243:
     optional: true
 
   electron-to-chromium@1.5.88: {}
@@ -6966,18 +6967,18 @@ snapshots:
 
   escape-string-regexp@4.0.0: {}
 
-  eslint-config-next@16.0.0(@typescript-eslint/parser@8.46.0(eslint@9.31.0(jiti@1.21.6))(typescript@5.8.3))(eslint@9.31.0(jiti@1.21.6))(typescript@5.8.3):
+  eslint-config-next@16.0.0(@typescript-eslint/parser@8.46.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3):
     dependencies:
       '@next/eslint-plugin-next': 16.0.0
-      eslint: 9.31.0(jiti@1.21.6)
+      eslint: 9.31.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@8.46.0(eslint@9.31.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.31.0(jiti@1.21.6))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.31.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.1)(eslint@9.31.0(jiti@1.21.6))
-      eslint-plugin-jsx-a11y: 6.10.0(eslint@9.31.0(jiti@1.21.6))
-      eslint-plugin-react: 7.37.1(eslint@9.31.0(jiti@1.21.6))
-      eslint-plugin-react-hooks: 7.0.0(eslint@9.31.0(jiti@1.21.6))
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@8.46.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.31.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.1)(eslint@9.31.0(jiti@2.6.1))
+      eslint-plugin-jsx-a11y: 6.10.0(eslint@9.31.0(jiti@2.6.1))
+      eslint-plugin-react: 7.37.1(eslint@9.31.0(jiti@2.6.1))
+      eslint-plugin-react-hooks: 7.0.0(eslint@9.31.0(jiti@2.6.1))
       globals: 16.4.0
-      typescript-eslint: 8.46.0(eslint@9.31.0(jiti@1.21.6))(typescript@5.8.3)
+      typescript-eslint: 8.46.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3)
     optionalDependencies:
       typescript: 5.8.3
     transitivePeerDependencies:
@@ -6985,9 +6986,9 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-config-prettier@10.1.8(eslint@9.31.0(jiti@1.21.6)):
+  eslint-config-prettier@10.1.8(eslint@9.31.0(jiti@2.6.1)):
     dependencies:
-      eslint: 9.31.0(jiti@1.21.6)
+      eslint: 9.31.0(jiti@2.6.1)
 
   eslint-import-resolver-node@0.3.9:
     dependencies:
@@ -6997,13 +6998,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.46.0(eslint@9.31.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.31.0(jiti@1.21.6)):
+  eslint-import-resolver-typescript@3.6.1(@typescript-eslint/parser@8.46.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.31.0(jiti@2.6.1)):
     dependencies:
       debug: 4.4.0
       enhanced-resolve: 5.18.3
-      eslint: 9.31.0(jiti@1.21.6)
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.46.0(eslint@9.31.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.31.0(jiti@1.21.6))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.31.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.1)(eslint@9.31.0(jiti@1.21.6))
+      eslint: 9.31.0(jiti@2.6.1)
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.46.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.31.0(jiti@2.6.1))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.1)(eslint@9.31.0(jiti@2.6.1))
       fast-glob: 3.3.2
       get-tsconfig: 4.10.1
       is-core-module: 2.15.1
@@ -7014,29 +7015,29 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.46.0(eslint@9.31.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.31.0(jiti@1.21.6)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.46.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.31.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.46.0(eslint@9.31.0(jiti@1.21.6))(typescript@5.8.3)
-      eslint: 9.31.0(jiti@1.21.6)
+      '@typescript-eslint/parser': 8.46.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3)
+      eslint: 9.31.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@8.46.0(eslint@9.31.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.31.0(jiti@1.21.6))
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@8.46.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.31.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.0(eslint@9.31.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.31.0(jiti@1.21.6)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.46.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.31.0(jiti@2.6.1)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
-      '@typescript-eslint/parser': 8.46.0(eslint@9.31.0(jiti@1.21.6))(typescript@5.8.3)
-      eslint: 9.31.0(jiti@1.21.6)
+      '@typescript-eslint/parser': 8.46.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3)
+      eslint: 9.31.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@8.46.0(eslint@9.31.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.31.0(jiti@1.21.6))
+      eslint-import-resolver-typescript: 3.6.1(@typescript-eslint/parser@8.46.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-plugin-import@2.32.0)(eslint@9.31.0(jiti@2.6.1))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.31.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.1)(eslint@9.31.0(jiti@1.21.6)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-typescript@3.6.1)(eslint@9.31.0(jiti@2.6.1)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -7045,9 +7046,9 @@ snapshots:
       array.prototype.flatmap: 1.3.3
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 9.31.0(jiti@1.21.6)
+      eslint: 9.31.0(jiti@2.6.1)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.0(eslint@9.31.0(jiti@1.21.6))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.31.0(jiti@1.21.6))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.46.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.6.1)(eslint@9.31.0(jiti@2.6.1))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -7059,13 +7060,13 @@ snapshots:
       string.prototype.trimend: 1.0.9
       tsconfig-paths: 3.15.0
     optionalDependencies:
-      '@typescript-eslint/parser': 8.46.0(eslint@9.31.0(jiti@1.21.6))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.46.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-jsx-a11y@6.10.0(eslint@9.31.0(jiti@1.21.6)):
+  eslint-plugin-jsx-a11y@6.10.0(eslint@9.31.0(jiti@2.6.1)):
     dependencies:
       aria-query: 5.1.3
       array-includes: 3.1.8
@@ -7076,7 +7077,7 @@ snapshots:
       damerau-levenshtein: 1.0.8
       emoji-regex: 9.2.2
       es-iterator-helpers: 1.0.19
-      eslint: 9.31.0(jiti@1.21.6)
+      eslint: 9.31.0(jiti@2.6.1)
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
       language-tags: 1.0.9
@@ -7085,18 +7086,18 @@ snapshots:
       safe-regex-test: 1.0.3
       string.prototype.includes: 2.0.0
 
-  eslint-plugin-react-hooks@7.0.0(eslint@9.31.0(jiti@1.21.6)):
+  eslint-plugin-react-hooks@7.0.0(eslint@9.31.0(jiti@2.6.1)):
     dependencies:
       '@babel/core': 7.26.10
       '@babel/parser': 7.27.0
-      eslint: 9.31.0(jiti@1.21.6)
+      eslint: 9.31.0(jiti@2.6.1)
       hermes-parser: 0.25.1
       zod: 3.24.2
       zod-validation-error: 3.3.1(zod@3.24.2)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-react@7.37.1(eslint@9.31.0(jiti@1.21.6)):
+  eslint-plugin-react@7.37.1(eslint@9.31.0(jiti@2.6.1)):
     dependencies:
       array-includes: 3.1.8
       array.prototype.findlast: 1.2.5
@@ -7104,7 +7105,7 @@ snapshots:
       array.prototype.tosorted: 1.1.4
       doctrine: 2.1.0
       es-iterator-helpers: 1.0.19
-      eslint: 9.31.0(jiti@1.21.6)
+      eslint: 9.31.0(jiti@2.6.1)
       estraverse: 5.3.0
       hasown: 2.0.2
       jsx-ast-utils: 3.3.5
@@ -7133,9 +7134,9 @@ snapshots:
 
   eslint-visitor-keys@4.2.1: {}
 
-  eslint@9.31.0(jiti@1.21.6):
+  eslint@9.31.0(jiti@2.6.1):
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@9.31.0(jiti@1.21.6))
+      '@eslint-community/eslint-utils': 4.4.0(eslint@9.31.0(jiti@2.6.1))
       '@eslint-community/regexpp': 4.12.1
       '@eslint/config-array': 0.21.0
       '@eslint/config-helpers': 0.3.0
@@ -7171,7 +7172,7 @@ snapshots:
       natural-compare: 1.4.0
       optionator: 0.9.4
     optionalDependencies:
-      jiti: 1.21.6
+      jiti: 2.6.1
     transitivePeerDependencies:
       - supports-color
 
@@ -7793,12 +7794,15 @@ snapshots:
 
   jest-worker@27.5.1:
     dependencies:
-      '@types/node': 22.18.12
+      '@types/node': 22.18.13
       merge-stream: 2.0.0
       supports-color: 8.1.1
     optional: true
 
-  jiti@1.21.6: {}
+  jiti@1.21.7: {}
+
+  jiti@2.6.1:
+    optional: true
 
   js-tokens@4.0.0: {}
 
@@ -8351,7 +8355,7 @@ snapshots:
 
   node-releases@2.0.19: {}
 
-  node-releases@2.0.26:
+  node-releases@2.0.27:
     optional: true
 
   normalize-path@3.0.0: {}
@@ -9155,7 +9159,7 @@ snapshots:
       fast-glob: 3.3.2
       glob-parent: 6.0.2
       is-glob: 4.0.3
-      jiti: 1.21.6
+      jiti: 1.21.7
       lilconfig: 3.1.3
       micromatch: 4.0.8
       normalize-path: 3.0.0
@@ -9334,13 +9338,13 @@ snapshots:
       possible-typed-array-names: 1.0.0
       reflect.getprototypeof: 1.0.6
 
-  typescript-eslint@8.46.0(eslint@9.31.0(jiti@1.21.6))(typescript@5.8.3):
+  typescript-eslint@8.46.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3):
     dependencies:
-      '@typescript-eslint/eslint-plugin': 8.46.0(@typescript-eslint/parser@8.46.0(eslint@9.31.0(jiti@1.21.6))(typescript@5.8.3))(eslint@9.31.0(jiti@1.21.6))(typescript@5.8.3)
-      '@typescript-eslint/parser': 8.46.0(eslint@9.31.0(jiti@1.21.6))(typescript@5.8.3)
+      '@typescript-eslint/eslint-plugin': 8.46.0(@typescript-eslint/parser@8.46.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3))(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3)
+      '@typescript-eslint/parser': 8.46.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3)
       '@typescript-eslint/typescript-estree': 8.46.0(typescript@5.8.3)
-      '@typescript-eslint/utils': 8.46.0(eslint@9.31.0(jiti@1.21.6))(typescript@5.8.3)
-      eslint: 9.31.0(jiti@1.21.6)
+      '@typescript-eslint/utils': 8.46.0(eslint@9.31.0(jiti@2.6.1))(typescript@5.8.3)
+      eslint: 9.31.0(jiti@2.6.1)
       typescript: 5.8.3
     transitivePeerDependencies:
       - supports-color
@@ -9461,13 +9465,13 @@ snapshots:
       unist-util-stringify-position: 4.0.0
       vfile-message: 4.0.2
 
-  vite-node@3.1.1(@types/node@22.3.0)(jiti@1.21.6)(terser@5.39.0)(tsx@4.19.4)(yaml@2.5.0):
+  vite-node@3.1.1(@types/node@22.3.0)(jiti@2.6.1)(terser@5.39.0)(tsx@4.19.4)(yaml@2.5.0):
     dependencies:
       cac: 6.7.14
       debug: 4.4.0
       es-module-lexer: 1.6.0
       pathe: 2.0.3
-      vite: 6.4.1(@types/node@22.3.0)(jiti@1.21.6)(terser@5.39.0)(tsx@4.19.4)(yaml@2.5.0)
+      vite: 6.4.1(@types/node@22.3.0)(jiti@2.6.1)(terser@5.39.0)(tsx@4.19.4)(yaml@2.5.0)
     transitivePeerDependencies:
       - '@types/node'
       - jiti
@@ -9482,7 +9486,7 @@ snapshots:
       - tsx
       - yaml
 
-  vite@6.4.1(@types/node@22.3.0)(jiti@1.21.6)(terser@5.39.0)(tsx@4.19.4)(yaml@2.5.0):
+  vite@6.4.1(@types/node@22.3.0)(jiti@2.6.1)(terser@5.39.0)(tsx@4.19.4)(yaml@2.5.0):
     dependencies:
       esbuild: 0.25.2
       fdir: 6.4.4(picomatch@4.0.2)
@@ -9493,15 +9497,15 @@ snapshots:
     optionalDependencies:
       '@types/node': 22.3.0
       fsevents: 2.3.3
-      jiti: 1.21.6
+      jiti: 2.6.1
       terser: 5.39.0
       tsx: 4.19.4
       yaml: 2.5.0
 
-  vitest@3.1.1(@types/debug@4.1.12)(@types/node@22.3.0)(jiti@1.21.6)(jsdom@26.1.0)(terser@5.39.0)(tsx@4.19.4)(yaml@2.5.0):
+  vitest@3.1.1(@types/debug@4.1.12)(@types/node@22.3.0)(jiti@2.6.1)(jsdom@26.1.0)(terser@5.39.0)(tsx@4.19.4)(yaml@2.5.0):
     dependencies:
       '@vitest/expect': 3.1.1
-      '@vitest/mocker': 3.1.1(vite@6.4.1(@types/node@22.3.0)(jiti@1.21.6)(terser@5.39.0)(tsx@4.19.4)(yaml@2.5.0))
+      '@vitest/mocker': 3.1.1(vite@6.4.1(@types/node@22.3.0)(jiti@2.6.1)(terser@5.39.0)(tsx@4.19.4)(yaml@2.5.0))
       '@vitest/pretty-format': 3.1.1
       '@vitest/runner': 3.1.1
       '@vitest/snapshot': 3.1.1
@@ -9517,8 +9521,8 @@ snapshots:
       tinyexec: 0.3.2
       tinypool: 1.0.2
       tinyrainbow: 2.0.0
-      vite: 6.4.1(@types/node@22.3.0)(jiti@1.21.6)(terser@5.39.0)(tsx@4.19.4)(yaml@2.5.0)
-      vite-node: 3.1.1(@types/node@22.3.0)(jiti@1.21.6)(terser@5.39.0)(tsx@4.19.4)(yaml@2.5.0)
+      vite: 6.4.1(@types/node@22.3.0)(jiti@2.6.1)(terser@5.39.0)(tsx@4.19.4)(yaml@2.5.0)
+      vite-node: 3.1.1(@types/node@22.3.0)(jiti@2.6.1)(terser@5.39.0)(tsx@4.19.4)(yaml@2.5.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/debug': 4.1.12

--- a/src/app/(cities)/bialystok/page.mdx
+++ b/src/app/(cities)/bialystok/page.mdx
@@ -1,4 +1,4 @@
-import { env } from '../../../env';
+import { env } from '@/env';
 import { CityEmail } from '../../../components/CityEmail';
 import { Organizers } from '../../../components/Organizers';
 import { FAQ } from '../../../components/FAQ';

--- a/src/app/(cities)/bielsko-biala/page.mdx
+++ b/src/app/(cities)/bielsko-biala/page.mdx
@@ -1,4 +1,4 @@
-import { env } from '../../../env';
+import { env } from '@/env';
 import { CityEmail } from '../../../components/CityEmail';
 import { Organizers } from '../../../components/Organizers';
 import { FAQ } from '../../../components/FAQ';

--- a/src/app/(cities)/gdansk/page.mdx
+++ b/src/app/(cities)/gdansk/page.mdx
@@ -1,4 +1,4 @@
-import { env } from '../../../env';
+import { env } from '@/env';
 import { CityEmail } from '../../../components/CityEmail';
 import { Organizers } from '../../../components/Organizers';
 import { FAQ } from '../../../components/FAQ';

--- a/src/app/(cities)/gliwice/page.mdx
+++ b/src/app/(cities)/gliwice/page.mdx
@@ -1,4 +1,4 @@
-import { env } from '../../../env';
+import { env } from '@/env';
 
 export const metadata = {
   title: 'meet.js Gliwice',

--- a/src/app/(cities)/katowice/page.mdx
+++ b/src/app/(cities)/katowice/page.mdx
@@ -1,4 +1,4 @@
-import { env } from '../../../env';
+import { env } from '@/env';
 import { Organizers } from '../../../components/Organizers';
 import { FAQ } from '../../../components/FAQ';
 import { CityBanner } from '../../../components/CityBanner';

--- a/src/app/(cities)/kielce/page.mdx
+++ b/src/app/(cities)/kielce/page.mdx
@@ -1,4 +1,4 @@
-import { env } from '../../../env';
+import { env } from '@/env';
 
 export const metadata = {
   title: 'meet.js Kielce',

--- a/src/app/(cities)/krakow/page.mdx
+++ b/src/app/(cities)/krakow/page.mdx
@@ -1,4 +1,4 @@
-import { env } from '../../../env';
+import { env } from '@/env';
 import { CityEmail } from '../../../components/CityEmail';
 import { Organizers } from '../../../components/Organizers';
 import { FAQ } from '../../../components/FAQ';

--- a/src/app/(cities)/lodz/page.mdx
+++ b/src/app/(cities)/lodz/page.mdx
@@ -1,4 +1,4 @@
-import { env } from '../../../env';
+import { env } from '@/env';
 import { CityBanner } from '../../../components/CityBanner';
 import { LocalGroups } from '../../../components/LocalGroups';
 import { CityEmail } from '../../../components/CityEmail';

--- a/src/app/(cities)/lublin/page.mdx
+++ b/src/app/(cities)/lublin/page.mdx
@@ -1,4 +1,4 @@
-import { env } from '../../../env';
+import { env } from '@/env';
 import { CityEmail } from '../../../components/CityEmail';
 import { Organizers } from '../../../components/Organizers';
 import { FAQ } from '../../../components/FAQ';

--- a/src/app/(cities)/olsztyn/page.mdx
+++ b/src/app/(cities)/olsztyn/page.mdx
@@ -1,4 +1,4 @@
-import { env } from '../../../env';
+import { env } from '@/env';
 
 export const metadata = {
   title: 'meet.js Olsztyn',

--- a/src/app/(cities)/opole/page.mdx
+++ b/src/app/(cities)/opole/page.mdx
@@ -1,4 +1,4 @@
-import { env } from '../../../env';
+import { env } from '@/env';
 
 export const metadata = {
   title: 'meet.js Opole',

--- a/src/app/(cities)/poznan/page.mdx
+++ b/src/app/(cities)/poznan/page.mdx
@@ -1,4 +1,4 @@
-import { env } from '../../../env';
+import { env } from '@/env';
 import { CityEmail } from '../../../components/CityEmail';
 import { Organizers } from '../../../components/Organizers';
 import { FAQ } from '../../../components/FAQ';

--- a/src/app/(cities)/rzeszow/page.mdx
+++ b/src/app/(cities)/rzeszow/page.mdx
@@ -1,4 +1,4 @@
-import { env } from '../../../env';
+import { env } from '@/env';
 
 export const metadata = {
   title: 'meet.js Rzeszów',

--- a/src/app/(cities)/szczecin/page.mdx
+++ b/src/app/(cities)/szczecin/page.mdx
@@ -1,4 +1,4 @@
-import { env } from '../../../env';
+import { env } from '@/env';
 
 export const metadata = {
   title: 'meet.js Szczecin',

--- a/src/app/(cities)/torun/page.mdx
+++ b/src/app/(cities)/torun/page.mdx
@@ -1,4 +1,4 @@
-import { env } from '../../../env';
+import { env } from '@/env';
 
 export const metadata = {
   title: 'meet.js Toruń',

--- a/src/app/(cities)/warszawa/page.mdx
+++ b/src/app/(cities)/warszawa/page.mdx
@@ -1,4 +1,4 @@
-import { env } from '../../../env';
+import { env } from '@/env';
 import { CityEmail } from '../../../components/CityEmail';
 import { Organizers } from '../../../components/Organizers';
 import { FAQ } from '../../../components/FAQ';

--- a/src/app/(cities)/wroclaw/page.mdx
+++ b/src/app/(cities)/wroclaw/page.mdx
@@ -1,4 +1,4 @@
-import { env } from '../../../env';
+import { env } from '@/env';
 import { CityEmail } from '../../../components/CityEmail';
 import { Organizers } from '../../../components/Organizers';
 import { FAQ } from '../../../components/FAQ';

--- a/src/app/(cities)/zielona-gora/page.mdx
+++ b/src/app/(cities)/zielona-gora/page.mdx
@@ -1,4 +1,4 @@
-import { env } from '../../../env';
+import { env } from '@/env';
 
 export const metadata = {
   title: 'meet.js Zielona Góra',


### PR DESCRIPTION
- Removed jiti dependency and its usage from next.config.ts
- Removed jiti from package.json and related dependency configurations
- Simplified environment configuration by removing jiti-based env loading

The changes appear to be an internal refactoring to simplify the configuration loading mechanism by removing the jiti