### PR TITLE
refactor: reorganize translation keys and add new organizer hub content

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -62,6 +62,12 @@
       "social_media": "Social media posts promoting meet.js events"
     },
     "allowed_uses": "Permitted Uses",
+    "assets_generator": "Event Image Generator",
+    "assets_generator_cta": "Open Generator",
+    "assets_generator_description": "Use the online generator to create visuals for meet.js events. Choose supporter type, add partner logos, and export ready-to-share images.",
+    "assets_generator_description_short": "Create event visuals quickly",
+    "assets_generator_subtitle": "Create meetup images for social media and banners.",
+    "assets_generator_title": "Event Image Generator",
     "bold_logos": "Bold Logos",
     "bold_logos_description": "Bold variant for prints and places where the official light logo would not be visible enough.",
     "bold_logos_print": "Bold Logos (Print)",
@@ -98,6 +104,8 @@
     "logo_variants_intro": "The meet.js logo is available in two main variants: light (official) and bold. Each variant serves different purposes and use cases:",
     "official_logos": "Official Logos",
     "official_print_variants": "Official & print variants",
+    "organizers_only_note": "Organizer-only resource:",
+    "organizers_tools_cta": "Organizer Tools",
     "original_colors": "Original Colors (Obsolete)",
     "original_colors_obsolete": "Original Colors (Obsolete)",
     "page_contents": "Page Contents",
@@ -117,15 +125,7 @@
     "usage_intro": "Please use these brand assets responsibly. Here are the key guidelines:",
     "usage_text": "Please use these assets responsibly and in accordance with our brand guidelines. For commercial use or questions about usage, please contact us.",
     "view_complete_collection_github": "View complete collection on GitHub",
-    "wallpapers": "Wallpapers",
-    "assets_generator": "Event Image Generator",
-    "assets_generator_description_short": "Create event visuals quickly",
-    "assets_generator_title": "Event Image Generator",
-    "assets_generator_subtitle": "Create meetup images for social media and banners.",
-    "assets_generator_description": "Use the online generator to create visuals for meet.js events. Choose supporter type, add partner logos, and export ready-to-share images.",
-    "assets_generator_cta": "Open Generator",
-    "organizers_only_note": "Organizer-only resource:",
-    "organizers_tools_cta": "Organizer Tools"
+    "wallpapers": "Wallpapers"
   },
   "communityParticipation": {
     "by_label": "By:",
@@ -290,24 +290,24 @@
     "contact": "Contact us",
     "copyright": "All rights reserved.",
     "menu": "Menu",
-    "status_legend_label": "Status:",
-    "status": {
-      "active": "Active",
-      "coming_soon": "Coming soon",
-      "paused": "Paused",
-      "new": "New"
-    },
     "menu_links": {
       "14_birthday": "14 Birthday",
       "about": "About",
-      "organizer_tools": "Organizer Tools",
       "brand_assets": "Brand Assets",
       "code_of_conduct": "Code of Conduct",
       "contact_link": "Contact",
       "events": "Events",
+      "organizer_tools": "Organizer Tools",
       "summit": "Summit",
       "wdi_2025": "WDI 2025"
-    }
+    },
+    "status": {
+      "active": "Active",
+      "coming_soon": "Coming soon",
+      "new": "New",
+      "paused": "Paused"
+    },
+    "status_legend_label": "Status:"
   },
   "hello_world": "Hello World",
   "hero": {
@@ -315,6 +315,7 @@
     "follow_us": "Follow us",
     "join_discord": "Join Discord",
     "ranking_banner": "#1 Tech Event Series in Poland (Crossweb 2024)",
+    "reach_conf_banner": "LIVE NOW: Reach Conference 2025 - Watch the stream!",
     "subtitle": "Join the largest JavaScript meetup community in Poland",
     "title": "meet.js"
   },
@@ -342,14 +343,14 @@
       "cities_label": "Cities",
       "code_of_conduct": "Code of Conduct",
       "coming_soon": "(Coming Soon)",
-      "community_partnerships": "Community Partnerships",
       "community_participation": "Community Participation",
+      "community_partnerships": "Community Partnerships",
       "event_discounts": "Event Discounts",
       "learning_discounts": "Learning Discounts",
+      "organizer_tools": "Organizer Tools",
       "our_team": "Our Team",
       "software_discounts": "Software Discounts",
-      "sponsors": "Sponsors",
-      "organizer_tools": "Organizer Tools"
+      "sponsors": "Sponsors"
     },
     "events": "Events",
     "home": "Home",
@@ -368,8 +369,28 @@
     "sponsors": "Sponsors",
     "team": "Team"
   },
-  
   "organizer": {
+    "assets_section": {
+      "current_logos": {
+        "available_formats": "Available formats:",
+        "description": "Download the official meet.js logos in various formats and colors for your events and materials.",
+        "title": "Current Logos"
+      },
+      "legacy_assets": {
+        "description": "Download historical meet.js branding materials including the original purple logos and summit-specific designs.",
+        "includes": "Includes:",
+        "title": "Legacy Assets"
+      },
+      "subtitle": "Download brand assets, logos, and visual materials for your meetups",
+      "title": "Brand Assets",
+      "wallpapers": {
+        "available": "Available:",
+        "description": "High-resolution desktop wallpapers featuring meet.js branding for your events and presentations.",
+        "title": "Desktop Wallpapers"
+      }
+    },
+    "back_to_main": "Back to",
+    "back_to_main_link": "How to become an organizer",
     "benefits": {
       "access": "Access to other organizers and their experience",
       "brand_access": "Access to the brand and the social media presence we have",
@@ -377,10 +398,43 @@
       "network": "Exposure to our network, including speakers that might want to visit your city",
       "sponsor_help": "Help when talking to sponsors and venues"
     },
+    "benefits_labels": {
+      "complete_toolkit": "Complete Organizer Toolkit",
+      "network_access": "Network Access & Intro Call",
+      "event_support": "Event Support & Sponsorship Help"
+    },
     "benefits_title": "What you'll get:",
+    "cities_section": {
+      "browse_cities": "Browse All Cities",
+      "description": "Explore meet.js communities across Poland and see where we're making an impact.",
+      "subtitle": "Active communities across Poland",
+      "title": "meet.js Cities"
+    },
+    "community_heart_description": "We're the heart of the JavaScript community in your city, bringing developers together for knowledge sharing, networking, and building lasting connections.",
     "contact_email": "contact@meetjs.pl",
     "contact_heading": "To start, reach out to",
     "contact_subject": "with the subject \"meet.js YOURCITY\"",
+    "cta_section": {
+      "description": "Ready to start organizing meetups and building the JavaScript community in your city? Let's get you started with all the resources and support you need.",
+      "start_journey": "Start Organizing Today",
+      "title": "Ready to Become a meet.js Organizer?"
+    },
+    "final_cta": {
+      "description": "Ready to bring meet.js to your city? Let's start building an amazing JavaScript community together!",
+      "title": "Ready to Start Your meet.js Journey?",
+      "view_resources": "View Organizer Resources"
+    },
+    "generator_cta": "Open Generator",
+    "generator_description": "Create meetup visuals for social media and banners with ease.",
+    "generator_title": "Event Image Generator",
+    "hub_page_subtitle": "Tools, resources, and support for meet.js organizers to build stronger JavaScript communities.",
+    "hub_page_title": "Organizer Resources",
+    "impact_items": {
+      "build_community": "Build a strong local JavaScript community",
+      "connect_developers": "Connect developers and foster collaboration",
+      "share_knowledge": "Share knowledge through talks and workshops",
+      "shape_future": "Shape the future of web development in your region"
+    },
     "intro_p1": "Do you wish to become an organizer and you need some help getting started? That's what we're here for!",
     "intro_p2": "If there's a meet.js in your city already, get in touch with the organizers to see how you can join.",
     "intro_p3": "If your city has a JavaScript crowd that's not organized yet or the local meetups are hosted by companies for short-term commercial or hiring reasons, you should definitely set up a meet.js in your city.",
@@ -390,20 +444,81 @@
       "money": "Money or anything of notable commercial value"
     },
     "no_benefits_title": "What you don't get:",
+    "organizer_description": "An organizer is a passionate individual who brings the JavaScript community together in their city. You don't need to be the most technical person – just someone who cares about connecting developers and building an amazing community.",
+    "organizer_impact": "Why Your Role Matters",
+    "page_subtitle": "Join our network of passionate organizers and help build stronger JavaScript communities across Poland.",
     "page_title": "How to become an organizer",
+    "process_steps": {
+      "contact_us": {
+        "description": "Reach out to our team with your city and motivation. We'll guide you through the next steps.",
+        "title": "Contact Us"
+      },
+      "first_event": {
+        "description": "Plan and host your first meetup with our support and guidance from experienced organizers.",
+        "title": "Host Your First Event"
+      },
+      "get_access": {
+        "description": "Get access to our organizer toolkit, brand assets, and connect with other organizers across Poland.",
+        "title": "Get Organizer Access"
+      },
+      "intro_call": {
+        "description": "Schedule a call with our team to discuss your city, expectations, and how we can support you.",
+        "title": "Intro Call"
+      },
+      "title": "Your Path to Becoming a meet.js Organizer"
+    },
+    "quick_actions": {
+      "become_organizer": "Become an Organizer",
+      "browse_events": "Browse Events",
+      "get_help": "Get Help",
+      "join_discord": "Join Discord"
+    },
+    "ready_to_start_cta": {
+      "description": "Ready to bring the meet.js community to your city? It only takes a few minutes to get started.",
+      "title": "Ready to Start?"
+    },
     "requirements": {
       "involvement": "Some involvement with JavaScript and programming community (being a dev yourself and enthusiastic about other humans)",
       "non_commercial": "No commercial interest or a company backing your engagement as an organizer",
       "time": "A bit of time and ambition"
     },
+    "requirements_labels": {
+      "community_spirit": "Community Spirit",
+      "non_commercial_approach": "Non-Commercial Approach",
+      "time_commitment": "Time Commitment"
+    },
     "requirements_title": "What you need to have:",
-    "tools_page_title": "Organizer Tools",
     "tools_intro": "Resources for meet.js organizers to create event visuals and assets.",
-    "generator_title": "Event Image Generator",
-    "generator_description": "Create meetup visuals for social media and banners with ease.",
-    "generator_cta": "Open Generator",
-    "back_to_main": "Back to",
-    "back_to_main_link": "How to become an organizer"
+    "tools_page_title": "Organizer Tools",
+    "tools_section": {
+      "event_management": {
+        "about_meetjs": "About meet.js",
+        "description": "Everything you need to know about organizing successful meet.js events, from planning to execution.",
+        "event_planning_guide": "Event Planning Guide",
+        "title": "Event Management"
+      },
+      "image_generator": {
+        "cta": "Open Generator",
+        "description": "Create professional event images with meet.js branding, partner logos, and customizable layouts.",
+        "title": "Image Generator"
+      },
+      "subtitle": "Essential tools to help you create amazing meetups",
+      "title": "Organizer Tools"
+    },
+    "what_is_organizer": "What is a meet.js Organizer?"
+  },
+  "organizers_hub": {
+    "cities_section": {
+      "browse_cities": "Browse All Cities",
+      "description": "Explore meet.js communities across Poland and see where we're making an impact.",
+      "subtitle": "Active communities across Poland",
+      "title": "meet.js Cities"
+    },
+    "cta_section": {
+      "description": "Ready to start organizing meetups and building the JavaScript community in your city? Let's get you started with all the resources and support you need.",
+      "start_journey": "Start Organizing Today",
+      "title": "Ready to Become a meet.js Organizer?"
+    }
   },
   "poland_map": {
     "active_upcoming_progress": "Active / upcoming / in progress",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -62,6 +62,12 @@
       "social_media": "Posty w mediach społecznościowych promujące wydarzenia meet.js"
     },
     "allowed_uses": "Dozwolone użycie",
+    "assets_generator": "Generator obrazów wydarzeń",
+    "assets_generator_cta": "Otwórz generator",
+    "assets_generator_description": "Skorzystaj z generatora online, aby tworzyć grafiki dla wydarzeń meet.js. Wybierz typ wsparcia, dodaj logotypy partnerów i eksportuj gotowe obrazy.",
+    "assets_generator_description_short": "Szybko twórz grafiki wydarzeń",
+    "assets_generator_subtitle": "Twórz grafiki meetupów do social mediów i banerów.",
+    "assets_generator_title": "Generator obrazów wydarzeń",
     "bold_logos": "Pogrubione loga",
     "bold_logos_description": "Pogrubiony wariant do druków i miejsc, gdzie oficjalne jasne logo nie byłoby wystarczająco widoczne.",
     "bold_logos_print": "Pogrubione loga (druk)",
@@ -98,6 +104,8 @@
     "logo_variants_intro": "Logo meet.js dostępne jest w dwóch głównych wariantach: jasny (oficjalny) i pogrubiony. Każdy wariant służy różnym celom i przypadkom użycia:",
     "official_logos": "Oficjalne loga",
     "official_print_variants": "Oficjalne i drukarskie warianty",
+    "organizers_only_note": "Zasób tylko dla organizatorów:",
+    "organizers_tools_cta": "Narzędzia dla organizatorów",
     "original_colors": "Oryginalne kolory (przestarzałe)",
     "original_colors_obsolete": "Oryginalne kolory (przestarzałe)",
     "page_contents": "Spis treści",
@@ -117,15 +125,7 @@
     "usage_intro": "Prosimy o odpowiedzialne używanie tych zasobów marki. Oto kluczowe wytyczne:",
     "usage_text": "Prosimy o odpowiedzialne używanie tych zasobów zgodnie z naszymi wytycznymi marki. W przypadku użytku komercyjnego lub pytań dotyczących użytkowania, skontaktuj się z nami.",
     "view_complete_collection_github": "Zobacz pełną kolekcję na GitHub",
-    "wallpapers": "Tapety",
-    "assets_generator": "Generator obrazów wydarzeń",
-    "assets_generator_description_short": "Szybko twórz grafiki wydarzeń",
-    "assets_generator_title": "Generator obrazów wydarzeń",
-    "assets_generator_subtitle": "Twórz grafiki meetupów do social mediów i banerów.",
-    "assets_generator_description": "Skorzystaj z generatora online, aby tworzyć grafiki dla wydarzeń meet.js. Wybierz typ wsparcia, dodaj logotypy partnerów i eksportuj gotowe obrazy.",
-    "assets_generator_cta": "Otwórz generator",
-    "organizers_only_note": "Zasób tylko dla organizatorów:",
-    "organizers_tools_cta": "Narzędzia dla organizatorów"
+    "wallpapers": "Tapety"
   },
   "communityParticipation": {
     "by_label": "Przez:",
@@ -290,24 +290,24 @@
     "contact": "Skontaktuj się z nami",
     "copyright": "Wszelkie prawa zastrzeżone.",
     "menu": "Menu",
-    "status_legend_label": "Status:",
-    "status": {
-      "active": "Aktywne",
-      "coming_soon": "Wkrótce",
-      "paused": "Wstrzymane",
-      "new": "Nowe"
-    },
     "menu_links": {
       "14_birthday": "14 urodziny",
       "about": "O nas",
-      "organizer_tools": "Narzędzia dla organizatorów",
       "brand_assets": "Logo i kolory",
       "code_of_conduct": "Kodeks postępowania",
       "contact_link": "Kontakt",
       "events": "Wydarzenia",
+      "organizer_tools": "Narzędzia dla organizatorów",
       "summit": "Summit",
       "wdi_2025": "WDI 2025"
-    }
+    },
+    "status": {
+      "active": "Aktywne",
+      "coming_soon": "Wkrótce",
+      "new": "Nowe",
+      "paused": "Wstrzymane"
+    },
+    "status_legend_label": "Status:"
   },
   "hello_world": "Witaj świecie",
   "hero": {
@@ -315,6 +315,7 @@
     "follow_us": "Śledź nas",
     "join_discord": "Dołącz do Discord",
     "ranking_banner": "#1 Seria Wydarzeń Tech w Polsce (Crossweb 2024)",
+    "reach_conf_banner": "NA ŻYWO: Konferencja Reach 2025 - Oglądaj transmisję!",
     "subtitle": "Dołącz do największej społeczności meetupów JavaScript w Polsce",
     "title": "meet.js"
   },
@@ -342,14 +343,14 @@
       "cities_label": "Miasta",
       "code_of_conduct": "Kodeks postępowania",
       "coming_soon": "(Wkrótce)",
-      "community_partnerships": "Partnerstwa Społeczne",
       "community_participation": "Udział w Społeczności",
+      "community_partnerships": "Partnerstwa Społeczne",
       "event_discounts": "Zniżki na wydarzenia",
       "learning_discounts": "Zniżki na naukę",
+      "organizer_tools": "Narzędzia dla organizatorów",
       "our_team": "Nasz zespół",
       "software_discounts": "Zniżki na oprogramowanie",
-      "sponsors": "Sponsorzy",
-      "organizer_tools": "Narzędzia dla organizatorów"
+      "sponsors": "Sponsorzy"
     },
     "events": "Wydarzenia",
     "home": "Strona główna",
@@ -369,6 +370,27 @@
     "team": "Zespół"
   },
   "organizer": {
+    "assets_section": {
+      "current_logos": {
+        "available_formats": "Dostępne formaty:",
+        "description": "Pobierz oficjalne logotypy meet.js w różnych formatach i kolorach na swoje wydarzenia i materiały.",
+        "title": "Aktualne Logotypy"
+      },
+      "legacy_assets": {
+        "description": "Pobierz historyczne materiały marki meet.js, w tym oryginalne purpurowe logotypy i projekty specyficzne dla summitu.",
+        "includes": "Zawiera:",
+        "title": "Historyczne Zasoby"
+      },
+      "subtitle": "Pobierz zasoby marki, logotypy i materiały wizualne na swoje meetupy",
+      "title": "Zasoby Marki",
+      "wallpapers": {
+        "available": "Dostępne:",
+        "description": "Tapety na pulpit w wysokiej rozdzielczości z marką meet.js na twoje wydarzenia i prezentacje.",
+        "title": "Tapety na Pulpit"
+      }
+    },
+    "back_to_main": "Powrót do",
+    "back_to_main_link": "Jak zostać organizatorem",
     "benefits": {
       "access": "Dostęp do innych organizatorów i ich doświadczenia",
       "brand_access": "Dostęp do marki i obecności w mediach społecznościowych, którą mamy",
@@ -376,10 +398,43 @@
       "network": "Dostęp do naszej sieci, w tym prelegentów, którzy mogą chcieć odwiedzić Twoje miasto",
       "sponsor_help": "Pomoc w rozmowach ze sponsorami i miejscami"
     },
+    "benefits_labels": {
+      "complete_toolkit": "Kompletny Zestaw Organizatora",
+      "network_access": "Dostęp do Sieci i Rozmowa Wprowadzająca",
+      "event_support": "Wsparcie Wydarzeń i Pomoc w Sponsorach"
+    },
     "benefits_title": "Co otrzymasz:",
+    "cities_section": {
+      "browse_cities": "Przeglądaj Wszystkie Miasta",
+      "description": "Poznaj społeczności meet.js w całej Polsce i zobacz, gdzie tworzymy wpływ.",
+      "subtitle": "Aktywne społeczności w całej Polsce",
+      "title": "Miasta meet.js"
+    },
+    "community_heart_description": "Jesteśmy sercem społeczności JavaScript w Twoim mieście, łącząc programistów w celu dzielenia się wiedzą, networkingu i budowania trwałych relacji.",
     "contact_email": "contact@meetjs.pl",
     "contact_heading": "Aby rozpocząć, skontaktuj się z",
     "contact_subject": "z tematem \"meet.js TWOJEMIASTO\"",
+    "cta_section": {
+      "description": "Gotowy zacząć organizować meetupy i budować społeczność JavaScript w swoim mieście? Zacznijmy od wszystkich zasobów i wsparcia, których potrzebujesz.",
+      "start_journey": "Zacznij Organizować Dziś",
+      "title": "Gotowy na Zostanie Organizatorem meet.js?"
+    },
+    "final_cta": {
+      "description": "Gotowy, by sprowadzić meet.js do swojego miasta? Zacznijmy razem budować niesamowitą społeczność JavaScript!",
+      "title": "Gotowy na Rozpoczęcie Swojej Przygody z meet.js?",
+      "view_resources": "Zobacz Zasoby dla Organizatorów"
+    },
+    "generator_cta": "Otwórz generator",
+    "generator_description": "Łatwo twórz grafiki meetupów do social mediów i banerów.",
+    "generator_title": "Generator obrazów wydarzeń",
+    "hub_page_subtitle": "Narzędzia, zasoby i wsparcie dla organizatorów meet.js do budowania silniejszych społeczności JavaScript.",
+    "hub_page_title": "Zasoby dla Organizatorów",
+    "impact_items": {
+      "build_community": "Zbuduj silną lokalną społeczność JavaScript",
+      "connect_developers": "Łącz programistów i wspieraj współpracę",
+      "share_knowledge": "Dziel się wiedzą poprzez prezentacje i warsztaty",
+      "shape_future": "Kształtuj przyszłość tworzenia stron internetowych w swoim regionie"
+    },
     "intro_p1": "Chcesz zostać organizatorem i potrzebujesz pomocy w rozpoczęciu? Po to tu jesteśmy!",
     "intro_p2": "Jeśli w Twoim mieście już istnieje meet.js, skontaktuj się z organizatorami, aby zobaczyć, jak możesz dołączyć.",
     "intro_p3": "Jeśli w Twoim mieście jest społeczność JavaScript, która nie jest jeszcze zorganizowana, lub lokalne meetupy są organizowane przez firmy w celach krótkoterminowych komercyjnych lub rekrutacyjnych, zdecydowanie powinieneś założyć meet.js w swoim mieście.",
@@ -389,20 +444,81 @@
       "money": "Pieniędzy ani niczego o znacznej wartości komercyjnej"
     },
     "no_benefits_title": "Czego nie otrzymasz:",
+    "organizer_description": "Organizator to pasjonat, który gromadzi społeczność JavaScript w swoim mieście. Nie musisz być najbardziej techniczną osobą – wystarczy, że zależy Ci na łączeniu programistów i budowaniu niesamowitej społeczności.",
+    "organizer_impact": "Dlaczego Twoja Rola Ma Znaczenie",
+    "page_subtitle": "Dołącz do naszej sieci pasjonatów-organizatorów i pomóż budować silniejsze społeczności JavaScript w całej Polsce.",
     "page_title": "Jak zostać organizatorem",
+    "process_steps": {
+      "contact_us": {
+        "description": "Skontaktuj się z naszym zespołem ze swoim miastem i motywacją. Poprowadzimy Cię przez kolejne kroki.",
+        "title": "Skontaktuj się z Nami"
+      },
+      "first_event": {
+        "description": "Zaplanuj i przeprowadź swoje pierwsze wydarzenie z naszym wsparciem i wskazówkami od doświadczonych organizatorów.",
+        "title": "Zorganizuj Swoje Pierwsze Wydarzenie"
+      },
+      "get_access": {
+        "description": "Otrzymaj dostęp do naszego zestawu narzędzi dla organizatorów, zasobów marki i połącz się z innymi organizatorami w całej Polsce.",
+        "title": "Otrzymaj Dostęp Organizatora"
+      },
+      "intro_call": {
+        "description": "Umów rozmowę z naszym zespołem, aby omówić Twoje miasto, oczekiwania i jak możemy Cię wspierać.",
+        "title": "Rozmowa Wprowadzająca"
+      },
+      "title": "Twoja Droga do Zostania Organizatorem meet.js"
+    },
+    "quick_actions": {
+      "become_organizer": "Zostań Organizatorem",
+      "browse_events": "Przeglądaj Wydarzenia",
+      "get_help": "Uzyskaj Pomoc",
+      "join_discord": "Dołącz do Discord"
+    },
+    "ready_to_start_cta": {
+      "description": "Gotowy, by sprowadzić społeczność meet.js do swojego miasta? Wystarczy kilka minut, aby rozpocząć.",
+      "title": "Gotowy na Start?"
+    },
     "requirements": {
       "involvement": "Pewne zaangażowanie w społeczność JavaScript i programowania (bycie deweloperem i entuzjastą innych ludzi)",
       "non_commercial": "Brak interesu komercyjnego lub wsparcia firmy w Twoim zaangażowaniu jako organizator",
       "time": "Trochę czasu i ambicji"
     },
+    "requirements_labels": {
+      "community_spirit": "Duch Społeczności",
+      "non_commercial_approach": "Podejście Niekomercyjne",
+      "time_commitment": "Zaangażowanie Czasowe"
+    },
     "requirements_title": "Co musisz mieć:",
-    "tools_page_title": "Narzędzia dla organizatorów",
     "tools_intro": "Zasoby dla organizatorów meet.js do tworzenia grafik i materiałów.",
-    "generator_title": "Generator obrazów wydarzeń",
-    "generator_description": "Łatwo twórz grafiki meetupów do social mediów i banerów.",
-    "generator_cta": "Otwórz generator",
-    "back_to_main": "Powrót do",
-    "back_to_main_link": "Jak zostać organizatorem"
+    "tools_page_title": "Narzędzia dla organizatorów",
+    "tools_section": {
+      "event_management": {
+        "about_meetjs": "O meet.js",
+        "description": "Wszystko, co musisz wiedzieć o organizacji udanych wydarzeń meet.js, od planowania do realizacji.",
+        "event_planning_guide": "Przewodnik Planowania Wydarzeń",
+        "title": "Zarządzanie Wydarzeniami"
+      },
+      "image_generator": {
+        "cta": "Otwórz Generator",
+        "description": "Twórz profesjonalne obrazy wydarzeń z marką meet.js, logotypami partnerów i konfigurowalnymi układami.",
+        "title": "Generator Obrazów"
+      },
+      "subtitle": "Niezbędne narzędzia, które pomogą Ci tworzyć niesamowite meetupy",
+      "title": "Narzędzia dla Organizatorów"
+    },
+    "what_is_organizer": "Kim jest Organizator meet.js?"
+  },
+  "organizers_hub": {
+    "cities_section": {
+      "browse_cities": "Przeglądaj Wszystkie Miasta",
+      "description": "Poznaj społeczności meet.js w całej Polsce i zobacz, gdzie tworzymy wpływ.",
+      "subtitle": "Aktywne społeczności w całej Polsce",
+      "title": "Miasta meet.js"
+    },
+    "cta_section": {
+      "description": "Gotowy zacząć organizować meetupy i budować społeczność JavaScript w swoim mieście? Zacznijmy od wszystkich zasobów i wsparcia, których potrzebujesz.",
+      "start_journey": "Zacznij Organizować Dziś",
+      "title": "Gotowy na Zostanie Organizatorem meet.js?"
+    }
   },
   "poland_map": {
     "active_upcoming_progress": "Aktywne / nadchodzące / w trakcie",

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,5 +1,3 @@
-import { fileURLToPath } from 'node:url';
-
 import createMDX from '@next/mdx';
 import { NextConfig } from 'next';
 
@@ -133,16 +131,6 @@ const nextConfig: NextConfig = {
       {
         source: '/youtube',
         destination: 'https://www.youtube.com/@meetjs',
-        permanent: true,
-      },
-      {
-        source: '/organizers',
-        destination: '/how-to-become-an-organizer',
-        permanent: true,
-      },
-      {
-        source: '/organization',
-        destination: '/how-to-become-an-organizer',
         permanent: true,
       },
       {

--- a/src/app/how-to-become-an-organizer/page.tsx
+++ b/src/app/how-to-become-an-organizer/page.tsx
@@ -1,78 +1,217 @@
 import Link from 'next/link';
+import Image from 'next/image';
+import { 
+  Mail, 
+  Users, 
+  Calendar, 
+  Heart, 
+  Handshake, 
+  BookOpen,
+  ExternalLink,
+  CheckCircle,
+  ArrowRight
+} from 'lucide-react';
 import { getTranslate } from '@/tolgee/server';
 
 export default async function Page() {
   const t = await getTranslate();
 
   return (
-    <div className="container mx-auto max-w-3xl py-16">
-      <h1 className="mb-8 text-4xl font-bold">{t('organizer.page_title')}</h1>
-
-      <div className="mb-8 space-y-4">
-        <p>
-          {t('organizer.intro_p1')}
-        </p>
-        <p>
-          {t('organizer.intro_p2')}
-        </p>
-        <p>
-          {t('organizer.intro_p3')}
+    <div className="container mx-auto max-w-4xl py-16">
+      <div className="mb-12 text-center">
+        <h1 className="mb-4 text-4xl font-bold">{t('organizer.page_title')}</h1>
+        <p className="text-lg text-gray-600 max-w-2xl mx-auto">
+          {t('organizer.page_subtitle')}
         </p>
       </div>
 
-      <div className="mb-8">
-        <h2 className="text-xl font-semibold">
-          {t('organizer.contact_heading')}{' '}
-          <a href="mailto:contact@meetjs.pl?subject=meet.js%20YOURCITY">
-            <strong>{t('organizer.contact_email')}</strong>
-          </a>{' '}
-          {t('organizer.contact_subject')}
-        </h2>
+      {/* Hero Image */}
+      <div className="mb-12">
+        <Image
+          src="/about/meetjs-organizers.jpg"
+          alt="meet.js organizers community"
+          width={1024}
+          height={400}
+          className="h-64 w-full rounded-lg object-cover shadow-lg"
+        />
       </div>
 
-      <div className="mb-8">
-        <h2 className="mb-4 text-2xl font-semibold">{t('organizer.requirements_title')}</h2>
-        <ul className="list-disc space-y-2 pl-6">
-          <li>{t('organizer.requirements.time')}</li>
-          <li>
-            {t('organizer.requirements.non_commercial')}
-          </li>
-          <li>
-            {t('organizer.requirements.involvement')}
-          </li>
-        </ul>
+      {/* Quick Start CTA */}
+      <div className="mb-12 rounded-lg bg-gradient-to-r from-purple-600 to-blue-600 p-8 text-white">
+        <div className="text-center">
+          <h2 className="mb-4 text-2xl font-bold">{t('organizer.ready_to_start_cta.title')}</h2>
+          <p className="mb-6 text-purple-100">
+            {t('organizer.ready_to_start_cta.description')}
+          </p>
+          <a 
+            href="mailto:contact@meetjs.pl?subject=meet.js%20YOURCITY"
+            className="inline-flex items-center gap-2 rounded-md bg-white px-6 py-3 text-purple-600 transition-colors hover:bg-gray-100"
+          >
+            <Mail className="h-4 w-4" />
+            {t('organizer.contact_heading')} <strong>{t('organizer.contact_email')}</strong>
+            <ExternalLink className="h-4 w-4" />
+          </a>
+        </div>
       </div>
 
-      <div className="mb-8">
-        <h2 className="mb-4 text-2xl font-semibold">{t('organizer.benefits_title')}</h2>
-        <ul className="list-disc space-y-2 pl-6">
-          <li>{t('organizer.benefits.access')}</li>
-          <li>
-            {t('organizer.benefits.intro_call')}
-          </li>
-          <li>{t('organizer.benefits.sponsor_help')}</li>
-          <li>{t('organizer.benefits.brand_access')}</li>
-          <li>
-            {t('organizer.benefits.network')}
-          </li>
-        </ul>
-      </div>
+      {/* Introduction */}
+      <section className="mb-12">
+        <div className="mb-8 space-y-4">
+          <p>{t('organizer.intro_p1')}</p>
+          <p>{t('organizer.intro_p2')}</p>
+          <p>{t('organizer.intro_p3')}</p>
+        </div>
+      </section>
 
-      <div>
-        <h2 className="mb-4 text-2xl font-semibold">
-          {t('organizer.no_benefits_title')}
-        </h2>
-        <ul className="list-disc space-y-2 pl-6">
-          <li>{t('organizer.no_benefits.money')}</li>
-        </ul>
-      </div>
+      {/* What is Organizer? */}
+      <section className="mb-12">
+        <h2 className="mb-6 text-3xl font-bold">{t('organizer.what_is_organizer')}</h2>
+        <div className="grid gap-8 md:grid-cols-2">
+          <div className="space-y-4">
+            <p className="text-gray-700">
+              {t('organizer.organizer_description')}
+            </p>
+            <p className="text-gray-700">
+              {t('organizer.community_heart_description')}
+            </p>
+          </div>
+          <div className="rounded-lg border bg-blue-50 p-6">
+            <h3 className="mb-4 text-xl font-semibold text-blue-800">{t('organizer.organizer_impact')}</h3>
+            <ul className="space-y-2">
+              <li className="flex items-center gap-2">
+                <CheckCircle className="h-5 w-5 text-green-600" />
+                <span>{t('organizer.impact_items.build_community')}</span>
+              </li>
+              <li className="flex items-center gap-2">
+                <CheckCircle className="h-5 w-5 text-green-600" />
+                <span>{t('organizer.impact_items.connect_developers')}</span>
+              </li>
+              <li className="flex items-center gap-2">
+                <CheckCircle className="h-5 w-5 text-green-600" />
+                <span>{t('organizer.impact_items.share_knowledge')}</span>
+              </li>
+              <li className="flex items-center gap-2">
+                <CheckCircle className="h-5 w-5 text-green-600" />
+                <span>{t('organizer.impact_items.shape_future')}</span>
+              </li>
+            </ul>
+          </div>
+        </div>
+      </section>
 
-      <div className="mt-12 rounded-lg border bg-white p-6 shadow-sm">
-        <h2 className="mb-2 text-2xl font-semibold">{t('organizer.tools_page_title')}</h2>
-        <p className="mb-4 text-gray-700">{t('organizer.tools_intro')}</p>
-        <Link href="/how-to-become-an-organizer/tools" className="inline-block rounded-md bg-blue-600 px-4 py-2 text-white transition-colors hover:bg-blue-700">
-          {t('organizer.tools_page_title')}
-        </Link>
+      {/* Requirements */}
+      <section className="mb-12">
+        <h2 className="mb-6 text-3xl font-bold">{t('organizer.requirements_title')}</h2>
+        <div className="grid gap-6 md:grid-cols-3">
+          <div className="rounded-lg border bg-white p-6 shadow-sm">
+            <Users className="mb-4 h-8 w-8 text-blue-600" />
+            <h3 className="mb-2 text-lg font-semibold">{t('organizer.requirements_labels.time_commitment')}</h3>
+            <p className="text-gray-600">{t('organizer.requirements.time')}</p>
+          </div>
+          <div className="rounded-lg border bg-white p-6 shadow-sm">
+            <Heart className="mb-4 h-8 w-8 text-red-600" />
+            <h3 className="mb-2 text-lg font-semibold">{t('organizer.requirements_labels.community_spirit')}</h3>
+            <p className="text-gray-600">{t('organizer.requirements.involvement')}</p>
+          </div>
+          <div className="rounded-lg border bg-white p-6 shadow-sm">
+            <Handshake className="mb-4 h-8 w-8 text-green-600" />
+            <h3 className="mb-2 text-lg font-semibold">{t('organizer.requirements_labels.non_commercial_approach')}</h3>
+            <p className="text-gray-600">{t('organizer.requirements.non_commercial')}</p>
+          </div>
+        </div>
+      </section>
+
+      {/* Benefits */}
+      <section className="mb-12">
+        <h2 className="mb-6 text-3xl font-bold">{t('organizer.benefits_title')}</h2>
+        <div className="grid gap-6 md:grid-cols-2">
+          <div className="space-y-6">
+            <div className="flex gap-4">
+              <BookOpen className="h-6 w-6 text-purple-600 mt-1" />
+              <div>
+                <h3 className="font-semibold">{t('organizer.benefits_labels.complete_toolkit')}</h3>
+                <p className="text-gray-600">{t('organizer.benefits.access')}</p>
+              </div>
+            </div>
+            <div className="flex gap-4">
+              <Users className="h-6 w-6 text-blue-600 mt-1" />
+              <div>
+                <h3 className="font-semibold">{t('organizer.benefits_labels.network_access')}</h3>
+                <p className="text-gray-600">{t('organizer.benefits.intro_call')}</p>
+              </div>
+            </div>
+            <div className="flex gap-4">
+              <Calendar className="h-6 w-6 text-green-600 mt-1" />
+              <div>
+                <h3 className="font-semibold">{t('organizer.benefits_labels.event_support')}</h3>
+                <p className="text-gray-600">{t('organizer.benefits.sponsor_help')}</p>
+              </div>
+            </div>
+          </div>
+          <div className="rounded-lg border bg-gray-50 p-6">
+            <h3 className="mb-4 font-semibold">{t('organizer.no_benefits_title')}</h3>
+            <p className="text-gray-600">{t('organizer.no_benefits.money')}</p>
+          </div>
+        </div>
+      </section>
+
+      {/* Process */}
+      <section className="mb-12">
+        <h2 className="mb-6 text-3xl font-bold">{t('organizer.process_steps.title')}</h2>
+        <div className="space-y-6">
+          <div className="flex gap-4">
+            <div className="flex h-8 w-8 items-center justify-center rounded-full bg-blue-600 text-white font-bold">1</div>
+            <div>
+              <h3 className="font-semibold">{t('organizer.process_steps.contact_us.title')}</h3>
+              <p className="text-gray-600">{t('organizer.process_steps.contact_us.description')}</p>
+            </div>
+          </div>
+          <div className="flex gap-4">
+            <div className="flex h-8 w-8 items-center justify-center rounded-full bg-blue-600 text-white font-bold">2</div>
+            <div>
+              <h3 className="font-semibold">{t('organizer.process_steps.intro_call.title')}</h3>
+              <p className="text-gray-600">{t('organizer.process_steps.intro_call.description')}</p>
+            </div>
+          </div>
+          <div className="flex gap-4">
+            <div className="flex h-8 w-8 items-center justify-center rounded-full bg-blue-600 text-white font-bold">3</div>
+            <div>
+              <h3 className="font-semibold">{t('organizer.process_steps.get_access.title')}</h3>
+              <p className="text-gray-600">{t('organizer.process_steps.get_access.description')}</p>
+            </div>
+          </div>
+          <div className="flex gap-4">
+            <div className="flex h-8 w-8 items-center justify-center rounded-full bg-blue-600 text-white font-bold">4</div>
+            <div>
+              <h3 className="font-semibold">{t('organizer.process_steps.first_event.title')}</h3>
+              <p className="text-gray-600">{t('organizer.process_steps.first_event.description')}</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* CTA Section */}
+      <div className="rounded-lg border bg-white p-8 text-center shadow-sm">
+        <h2 className="mb-4 text-2xl font-bold">{t('organizer.final_cta.title')}</h2>
+        <p className="mb-6 text-gray-600">
+          {t('organizer.final_cta.description')}
+        </p>
+        <div className="flex flex-col gap-4 sm:flex-row sm:justify-center">
+          <a 
+            href="mailto:contact@meetjs.pl?subject=meet.js%20YOURCITY"
+            className="inline-flex items-center justify-center gap-2 rounded-md bg-blue-600 px-6 py-3 text-white transition-colors hover:bg-blue-700"
+          >
+            <Mail className="h-4 w-4" />
+            {t('organizer.contact_heading')} <strong>{t('organizer.contact_email')}</strong>
+          </a>
+          <Link 
+            href="/organizers"
+            className="inline-flex items-center justify-center gap-2 rounded-md border border-gray-300 px-6 py-3 text-gray-700 transition-colors hover:bg-gray-50"
+          >
+            {t('organizer.final_cta.view_resources')}
+            <ArrowRight className="h-4 w-4" />
+          </Link>
+        </div>
       </div>
     </div>
   );

--- a/src/app/organizers/page.tsx
+++ b/src/app/organizers/page.tsx
@@ -1,0 +1,229 @@
+import { Metadata } from 'next';
+import Image from 'next/image';
+import { 
+  Users, 
+  Calendar, 
+  Palette, 
+  FileText, 
+  Download,
+  Mail,
+  ExternalLink,
+  Image as ImageIcon,
+  CalendarDays,
+  Heart
+} from 'lucide-react';
+import { getTranslate } from '@/tolgee/server';
+
+export const metadata: Metadata = {
+  title: 'Organizer Resources | meet.js',
+  description: 'Tools, assets, and resources for meet.js organizers',
+};
+
+export default async function OrganizersPage() {
+  const t = await getTranslate();
+
+  return (
+    <div className="container mx-auto max-w-6xl py-16">
+      <div className="mb-12 text-center">
+        <h1 className="mb-4 text-4xl font-bold">{t('organizer.hub_page_title')}</h1>
+        <p className="text-lg text-gray-600 max-w-2xl mx-auto">
+          {t('organizer.hub_page_subtitle')}
+        </p>
+      </div>
+
+      {/* Quick Actions */}
+      <div className="mb-16 grid gap-4 md:grid-cols-2 lg:grid-cols-4">
+        <a 
+          href="/how-to-become-an-organizer"
+          className="rounded-lg border bg-blue-50 p-4 text-center transition-colors hover:bg-blue-100"
+        >
+          <Users className="mx-auto mb-2 h-6 w-6 text-blue-600" />
+          <p className="font-medium text-blue-800">{t('organizer.quick_actions.become_organizer')}</p>
+        </a>
+        <a 
+          href="/events"
+          className="rounded-lg border bg-green-50 p-4 text-center transition-colors hover:bg-green-100"
+        >
+          <Calendar className="mx-auto mb-2 h-6 w-6 text-green-600" />
+          <p className="font-medium text-green-800">{t('organizer.quick_actions.browse_events')}</p>
+        </a>
+        <a 
+          href="https://discord.gg/8r9XKTeNW8"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="rounded-lg border bg-purple-50 p-4 text-center transition-colors hover:bg-purple-100"
+        >
+          <ExternalLink className="mx-auto mb-2 h-6 w-6 text-purple-600" />
+          <p className="font-medium text-purple-800">{t('organizer.quick_actions.join_discord')}</p>
+        </a>
+        <a 
+          href="mailto:contact@meetjs.pl"
+          className="rounded-lg border bg-orange-50 p-4 text-center transition-colors hover:bg-orange-100"
+        >
+          <Mail className="mx-auto mb-2 h-6 w-6 text-orange-600" />
+          <p className="font-medium text-orange-800">{t('organizer.quick_actions.get_help')}</p>
+        </a>
+      </div>
+
+      {/* Tools Section */}
+      <section id="tools" className="mb-16">
+        <div className="mb-8 text-center">
+          <h2 className="mb-4 text-3xl font-bold">{t('organizer.tools_section.title')}</h2>
+          <p className="text-gray-600">{t('organizer.tools_section.subtitle')}</p>
+        </div>
+
+        <div className="grid gap-8 md:grid-cols-2">
+          <div className="rounded-lg border bg-white p-6 shadow-sm">
+            <div className="mb-4 flex items-center gap-3">
+              <ImageIcon className="h-6 w-6 text-purple-600" />
+              <h3 className="text-xl font-semibold">{t('organizer.tools_section.image_generator.title')}</h3>
+            </div>
+            <p className="mb-4 text-gray-600">
+              {t('organizer.tools_section.image_generator.description')}
+            </p>
+            <a
+              href="https://meetjspl.github.io/assets-generator/"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 rounded-md bg-purple-600 px-4 py-2 text-white transition-colors hover:bg-purple-700"
+            >
+              <Download className="h-4 w-4" />
+              {t('organizer.tools_section.image_generator.cta')}
+              <ExternalLink className="h-3 w-3" />
+            </a>
+          </div>
+
+          <div className="rounded-lg border bg-white p-6 shadow-sm">
+            <div className="mb-4 flex items-center gap-3">
+              <CalendarDays className="h-6 w-6 text-blue-600" />
+              <h3 className="text-xl font-semibold">{t('organizer.tools_section.event_management.title')}</h3>
+            </div>
+            <p className="mb-4 text-gray-600">
+              {t('organizer.tools_section.event_management.description')}
+            </p>
+            <div className="space-y-2">
+              <a 
+                href="/how-to-become-an-organizer"
+                className="block text-blue-600 hover:underline"
+              >
+                {t('organizer.tools_section.event_management.event_planning_guide')} →
+              </a>
+              <a 
+                href="/about"
+                className="block text-blue-600 hover:underline"
+              >
+                {t('organizer.tools_section.event_management.about_meetjs')} →
+              </a>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Assets Section */}
+      <section id="assets" className="mb-16">
+        <div className="mb-8 text-center">
+          <h2 className="mb-4 text-3xl font-bold">{t('organizer.assets_section.title')}</h2>
+          <p className="text-gray-600">{t('organizer.assets_section.subtitle')}</p>
+        </div>
+
+        <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+          <div className="rounded-lg border bg-white p-6 shadow-sm">
+            <div className="mb-4 flex items-center gap-3">
+              <FileText className="h-6 w-6 text-green-600" />
+              <h3 className="text-lg font-semibold">{t('organizer.assets_section.current_logos.title')}</h3>
+            </div>
+            <p className="mb-4 text-sm text-gray-600">
+              {t('organizer.assets_section.current_logos.description')}
+            </p>
+            <div className="space-y-2 text-sm">
+              <p className="text-gray-500">{t('organizer.assets_section.current_logos.available_formats')}</p>
+              <ul className="list-disc pl-4 text-gray-600">
+                <li>SVG format</li>
+                <li>PNG format</li>
+                <li>Multiple colors</li>
+                <li>Square variants</li>
+              </ul>
+            </div>
+          </div>
+
+          <div className="rounded-lg border bg-white p-6 shadow-sm">
+            <div className="mb-4 flex items-center gap-3">
+              <Heart className="h-6 w-6 text-red-600" />
+              <h3 className="text-lg font-semibold">{t('organizer.assets_section.legacy_assets.title')}</h3>
+            </div>
+            <p className="mb-4 text-sm text-gray-600">
+              {t('organizer.assets_section.legacy_assets.description')}
+            </p>
+            <div className="space-y-2 text-sm">
+              <p className="text-gray-500">{t('organizer.assets_section.legacy_assets.includes')}</p>
+              <ul className="list-disc pl-4 text-gray-600">
+                <li>Purple logo variants</li>
+                <li>Summit specific logos</li>
+                <li>Print materials</li>
+                <li>Historical branding</li>
+              </ul>
+            </div>
+          </div>
+
+          <div className="rounded-lg border bg-white p-6 shadow-sm">
+            <div className="mb-4 flex items-center gap-3">
+              <ImageIcon className="h-6 w-6 text-blue-600" />
+              <h3 className="text-lg font-semibold">{t('organizer.assets_section.wallpapers.title')}</h3>
+            </div>
+            <p className="mb-4 text-sm text-gray-600">
+              {t('organizer.assets_section.wallpapers.description')}
+            </p>
+            <div className="space-y-2 text-sm">
+              <p className="text-gray-500">{t('organizer.assets_section.wallpapers.available')}</p>
+              <ul className="list-disc pl-4 text-gray-600">
+                <li>1920x1080 resolution</li>
+                <li>Meet.js cover images</li>
+                <li>Various themes</li>
+                <li>Social media ready</li>
+              </ul>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Cities Section */}
+      <section id="cities" className="mb-16">
+        <div className="mb-8 text-center">
+          <h2 className="mb-4 text-3xl font-bold">{t('organizers_hub.cities_section.title')}</h2>
+          <p className="text-gray-600">{t('organizers_hub.cities_section.subtitle')}</p>
+        </div>
+
+        <div className="rounded-lg border bg-white p-8">
+          <p className="mb-6 text-center text-gray-600">
+            {t('organizers_hub.cities_section.description')}
+          </p>
+          <div className="text-center">
+            <a
+              href="/events"
+              className="inline-flex items-center rounded-md bg-blue-600 px-6 py-3 text-white transition-colors hover:bg-blue-700"
+            >
+              {t('organizers_hub.cities_section.browse_cities')}
+            </a>
+          </div>
+        </div>
+      </section>
+
+      {/* New Organizer CTA */}
+      <div className="rounded-lg bg-gradient-to-r from-blue-600 to-purple-600 p-8 text-white">
+        <div className="text-center">
+          <h2 className="mb-4 text-2xl font-bold">{t('organizers_hub.cta_section.title')}</h2>
+          <p className="mb-6 max-w-2xl mx-auto text-blue-100">
+            {t('organizers_hub.cta_section.description')}
+          </p>
+          <a 
+            href="/how-to-become-an-organizer"
+            className="inline-flex items-center rounded-md bg-white px-6 py-3 text-blue-600 transition-colors hover:bg-gray-100"
+          >
+            {t('organizers_hub.cta_section.start_journey')}
+            <ExternalLink className="ml-2 h-4 w-4" />
+          </a>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -75,6 +75,12 @@ const sitemap = (): MetadataRoute.Sitemap => {
       changeFrequency: 'monthly',
       priority: 0.7,
     },
+    {
+      url: `${env.SITE_URL}/organizers`,
+      lastModified: currentDate,
+      changeFrequency: 'monthly',
+      priority: 0.7,
+    },
   ];
 
   return [...mainPages, ...cities];

--- a/src/hooks/useTranslatedMenuLinks.ts
+++ b/src/hooks/useTranslatedMenuLinks.ts
@@ -109,7 +109,7 @@ export const useTranslatedMenuLinks = (): MenuLink[] => {
         },
         {
           name: t('navigation.dropdown.organizer_tools'),
-          href: '/how-to-become-an-organizer/tools',
+          href: '/organizers',
           type: 'link',
         },
         {
@@ -163,7 +163,7 @@ export const useTranslatedFooterMenuLinks = (): MenuLink[] => {
     },
     {
       name: t('footer.menu_links.organizer_tools'),
-      href: '/how-to-become-an-organizer/tools',
+      href: '/organizers',
       current: false,
       external: false,
     },
@@ -225,7 +225,7 @@ export const getTranslatedFooterMenuLinks = async (): Promise<MenuLink[]> => {
     },
     {
       name: t('footer.menu_links.organizer_tools'),
-      href: '/how-to-become-an-organizer/tools',
+      href: '/organizers',
       current: false,
       external: false,
     },


### PR DESCRIPTION
- Alphabetically sort translation keys within sections for better maintainability
- Add comprehensive organizer hub translations including assets, tools, and process sections
- Add "Reach Conference 2025" live stream banner to hero section
- Expand organizer resources with detailed descriptions for brand assets, event management, and image generator
- Add new CTA sections for organizer recruitment and journey steps

<img width="2634" height="7314" alt="website-git-feat-update-organizers-page-meetjs-projects vercel app_how-to-become-an-organizer" src="https://github.com/user-attachments/assets/9d6d0ebf-3afc-4087-bbbd-a6ea59df6e04" />
<img width="2634" height="5338" alt="website-git-feat-update-organizers-page-meetjs-projects vercel app_organizers" src="https://github.com/user-attachments/assets/df2c7afe-9aa8-4e4b-b28b-62a68d3cdd27" />

