### PR TITLE
fix(typography): &#39; was displaying as &#39; not ' when placed in timelineEvents objects strings

### DIFF
--- a/src/components/JavaScriptTimeline.tsx
+++ b/src/components/JavaScriptTimeline.tsx
@@ -36,7 +36,7 @@ const timelineEvents = [
     year: '2005',
     title: 'AJAX Revolution',
     description:
-      'Google Maps and Gmail popularize AJAX, showcasing JavaScript&#39;s potential for rich web applications.',
+      "Google Maps and Gmail popularize AJAX, showcasing JavaScript's potential for rich web applications.",
     icon: '🌐',
   },
   {
@@ -120,7 +120,7 @@ const timelineEvents = [
     year: '2020',
     title: 'JavaScript Everywhere',
     description:
-      'JavaScript dominates web development with frameworks like React, Vue, and Angular. Node.js powers backend services, and JavaScript runs on mobile, desktop, and IoT devices. It&#39;s truly everywhere in the tech stack.',
+      "JavaScript dominates web development with frameworks like React, Vue, and Angular. Node.js powers backend services, and JavaScript runs on mobile, desktop, and IoT devices. It's truly everywhere in the tech stack.",
     icon: '🌐',
   },
   {


### PR DESCRIPTION
Hej!
Zauważyłam, że na podstronie [30 Years of JavaScript](https://meetjs.pl/30-years-of-javascript) w dwóch miejscach znak `&#39;` (apostrof) wyświetla się właśnie jako `&#39;`, zamiast `'`.
<img width="496" height="243" alt="image" src="https://github.com/user-attachments/assets/a5b4a990-a4ff-48ff-97f7-ee3ba4c0e286" />

Jest to spowodowane tym, że nie wyświetlamy tego tekstu bezpośrednio - jest on umieszczony jako właściwość typu `string` obiektu.

Na początku chciałam zrobić to w taki sposób:
```javascript
    description:
      'Google Maps and Gmail popularize AJAX, showcasing JavaScript\'s potential for rich web applications.',
```

Jednak ESLint woli unikać użytkowania `\`:
```
Replace `'Google·Maps·and·Gmail·popularize·AJAX,·showcasing·JavaScript\'s·potential·for·rich·web·applications.'` with `"Google·Maps·and·Gmail·popularize·AJAX,·showcasing·JavaScript's·potential·for·rich·web·applications."`eslint[prettier/prettier](https://github.com/prettier/eslint-plugin-prettier#options)
```

