### PR TITLE
refactor: disable caching for events API requests

### DIFF
--- a/src/app/events/page.tsx
+++ b/src/app/events/page.tsx
@@ -25,7 +25,7 @@ const getPastEvents = async () => {
     url.searchParams.set('old', '1');
 
     const pastEventsRes = await fetch(url, {
-      next: { revalidate: 3600 },
+      cache: 'no-store',
     });
 
     if (!pastEventsRes.ok) {

--- a/src/utils/getUpcomingEvents.ts
+++ b/src/utils/getUpcomingEvents.ts
@@ -5,9 +5,7 @@ import { changeCityName } from '@/utils/changeCityName';
 export const getUpcomingEvents = async () => {
   try {
     const upcomingEventsRes = await fetch(new URL(env.EVENTS_API_URL), {
-      next: {
-        revalidate: 3600, // Cache for 1 hour (in seconds)
-      },
+      cache: 'no-store',
     });
 
     const upcomingEventsJson = await upcomingEventsRes.json();


### PR DESCRIPTION
- Replace revalidate cache strategy with no-store for past events fetch
- Replace revalidate cache strategy with no-store for upcoming events fetch
- Remove cache duration comments