### PR TITLE
feat(promo-banners): move PromoBanners above Navigation in layout hierarchy

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -12,6 +12,10 @@ import { TolgeeNextProvider } from '@/tolgee/client';
 import { getTolgee } from '@/tolgee/server';
 import { getLanguage } from '@/tolgee/language';
 import { Snow } from '@/components/Snow';
+import { PromoBanners } from '@/components/PromoBanners';
+import { softwareDiscounts } from '@/content/software-discounts';
+import { eventsDiscounts } from '@/content/events-discounts';
+import { learningDiscounts } from '@/content/learning-discounts';
 
 const montserrat = Montserrat({
   subsets: ['latin'],
@@ -123,6 +127,13 @@ const RootLayout = async ({
     >
       <body>
         <TolgeeNextProvider language={locale} staticData={staticData}>
+          <PromoBanners
+            promos={[
+              ...eventsDiscounts,
+              ...softwareDiscounts,
+              ...learningDiscounts,
+            ]}
+          />
           <Navigation />
           {children}
           <Footer />

--- a/src/components/BirthdayConfetti.tsx
+++ b/src/components/BirthdayConfetti.tsx
@@ -21,7 +21,7 @@ export const BirthdayConfetti = () => {
   }, []);
 
   return showConfetti ? (
-    <div className="pointer-events-none fixed inset-0 z-50">
+    <div className="pointer-events-none fixed inset-0 z-[80]">
       <Confetti
         numberOfPieces={200}
         recycle={true}

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -3,31 +3,17 @@
 import { Disclosure } from '@headlessui/react';
 import { Logo } from '@/components/Logo';
 import { SocialLinks } from '@/components/SocialLinks';
-import { PromoBanners } from '@/components/PromoBanners';
-import { softwareDiscounts } from '@/content/software-discounts';
-import { eventsDiscounts } from '@/content/events-discounts';
+
 import { DesktopNavigation } from './Navigation/DesktopNavigation';
 import { MobileNavigation } from './Navigation/MobileNavigation';
 import { MobileMenuButton } from './Navigation/MobileMenuButton';
-import { learningDiscounts } from '@/content/learning-discounts';
 import { LanguageSwitcher } from './LanguageSwitcher';
 
 export const Navigation = () => {
   return (
     <>
-      <PromoBanners
-        promos={[
-          ...eventsDiscounts,
-          ...softwareDiscounts,
-          ...learningDiscounts,
-        ]}
-      />
-      <header role="banner" suppressHydrationWarning>
-        <Disclosure
-          as="nav"
-          className="sticky top-0 z-20 bg-purple"
-          aria-label="Main navigation"
-        >
+      <header role="banner" className="sticky top-0 z-50">
+        <Disclosure as="nav" className="bg-purple" aria-label="Main navigation">
           {({ open }) => (
             <>
               <div className="mx-auto max-w-7xl px-2 sm:px-6 lg:px-8">

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -12,7 +12,7 @@ import { LanguageSwitcher } from './LanguageSwitcher';
 export const Navigation = () => {
   return (
     <>
-      <header role="banner" className="sticky top-0 z-50">
+      <header role="banner" className="sticky top-0 z-40">
         <Disclosure as="nav" className="bg-purple" aria-label="Main navigation">
           {({ open }) => (
             <>

--- a/src/components/Snow.tsx
+++ b/src/components/Snow.tsx
@@ -23,5 +23,13 @@ export const Snow = () => {
     });
   }, []);
 
-  return init && <Particles id="tsparticles" options={snowConfig} />;
+  return (
+    init && (
+      <Particles
+        id="tsparticles"
+        options={snowConfig}
+        className="pointer-events-none fixed inset-0 z-[100]"
+      />
+    )
+  );
 };


### PR DESCRIPTION
- Move PromoBanners from Navigation component to RootLayout
- Update Navigation header to use sticky positioning with z-50
- Remove suppressHydrationWarning from header element
- Consolidate promo data imports (software, events, learning discounts) in layout
- Improve banner positioning to appear above sticky navigation