### PR TITLE
feat(seasonal-theme): centralize seasonal theme logic in utility function

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,12 +11,12 @@ import { env } from '@/env';
 import { TolgeeNextProvider } from '@/tolgee/client';
 import { getTolgee } from '@/tolgee/server';
 import { getLanguage } from '@/tolgee/language';
-import { Snow } from '@/components/Snow';
 import { PromoBanners } from '@/components/PromoBanners';
 import { softwareDiscounts } from '@/content/software-discounts';
 import { eventsDiscounts } from '@/content/events-discounts';
 import { learningDiscounts } from '@/content/learning-discounts';
-import { getSeasonalTheme } from '@/lib/seasonalTheme';
+import { SeasonalEffects } from '@/components/SeasonalEffects';
+import { SeasonalControls } from '@/components/SeasonalControls';
 
 const montserrat = Montserrat({
   subsets: ['latin'],
@@ -117,8 +117,6 @@ const RootLayout = async ({
   const locale = await getLanguage();
   const tolgee = await getTolgee();
 
-  const { enableSnow } = getSeasonalTheme();
-
   // serializable data that are passed to client components
   const staticData = await tolgee.loadRequired();
 
@@ -144,7 +142,8 @@ const RootLayout = async ({
         <Analytics />
         <SpeedInsights />
         <SchemaMarkup />
-        {enableSnow && <Snow />}
+        <SeasonalEffects />
+        <SeasonalControls />
       </body>
     </html>
   );

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,6 +16,7 @@ import { PromoBanners } from '@/components/PromoBanners';
 import { softwareDiscounts } from '@/content/software-discounts';
 import { eventsDiscounts } from '@/content/events-discounts';
 import { learningDiscounts } from '@/content/learning-discounts';
+import { getSeasonalTheme } from '@/lib/seasonalTheme';
 
 const montserrat = Montserrat({
   subsets: ['latin'],
@@ -116,6 +117,8 @@ const RootLayout = async ({
   const locale = await getLanguage();
   const tolgee = await getTolgee();
 
+  const { enableSnow } = getSeasonalTheme();
+
   // serializable data that are passed to client components
   const staticData = await tolgee.loadRequired();
 
@@ -141,7 +144,7 @@ const RootLayout = async ({
         <Analytics />
         <SpeedInsights />
         <SchemaMarkup />
-        <Snow />
+        {enableSnow && <Snow />}
       </body>
     </html>
   );

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -4,6 +4,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useState } from 'react';
 import { useTranslate } from '@tolgee/react';
+import { getSeasonalTheme } from '@/lib/seasonalTheme';
 
 interface LogoProps {
   clickable?: boolean;
@@ -28,13 +29,11 @@ export const Logo = ({ clickable = true }: LogoProps) => {
     setShowContextMenu(false);
   };
 
-  const now = new Date();
-  const isChristmasSeason =
-    now.getMonth() === 11 || (now.getMonth() === 0 && now.getDate() <= 15);
+  const { logoSrc } = getSeasonalTheme();
 
   const logoImage = (
     <Image
-      src={isChristmasSeason ? './christmas_logo.svg' : './logo.svg'}
+      src={logoSrc}
       alt="meet.js Logo"
       width={150}
       height={40}

--- a/src/components/Logo.tsx
+++ b/src/components/Logo.tsx
@@ -4,7 +4,8 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useState } from 'react';
 import { useTranslate } from '@tolgee/react';
-import { getSeasonalTheme } from '@/lib/seasonalTheme';
+import { getSeasonalThemeWithMode } from '@/lib/seasonalTheme';
+import { useSeasonalPreferences } from '@/hooks/useSeasonalPreferences';
 
 interface LogoProps {
   clickable?: boolean;
@@ -12,6 +13,7 @@ interface LogoProps {
 
 export const Logo = ({ clickable = true }: LogoProps) => {
   const { t } = useTranslate();
+  const { themeMode } = useSeasonalPreferences();
   const [showContextMenu, setShowContextMenu] = useState(false);
   const [contextMenuPosition, setContextMenuPosition] = useState({
     x: 0,
@@ -29,7 +31,7 @@ export const Logo = ({ clickable = true }: LogoProps) => {
     setShowContextMenu(false);
   };
 
-  const { logoSrc } = getSeasonalTheme();
+  const { logoSrc } = getSeasonalThemeWithMode(new Date(), themeMode);
 
   const logoImage = (
     <Image

--- a/src/components/SeasonalControls.tsx
+++ b/src/components/SeasonalControls.tsx
@@ -1,0 +1,82 @@
+'use client';
+
+import { useMemo } from 'react';
+import { Settings2 } from 'lucide-react';
+import { useSeasonalPreferences } from '@/hooks/useSeasonalPreferences';
+import type { SeasonalThemeMode } from '@/lib/seasonalTheme';
+import type { SeasonalSnowMode } from '@/hooks/useSeasonalPreferences';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+
+export const SeasonalControls = () => {
+  const { themeMode, setThemeMode, snowMode, setSnowMode } =
+    useSeasonalPreferences();
+
+  const themeLabel = useMemo(() => {
+    if (themeMode === 'christmas') return 'Christmas';
+    if (themeMode === 'default') return 'Default';
+    return 'Auto';
+  }, [themeMode]);
+
+  const snowLabel = useMemo(() => {
+    if (snowMode === 'on') return 'On';
+    if (snowMode === 'off') return 'Off';
+    return 'Auto';
+  }, [snowMode]);
+
+  return (
+    <div className="fixed bottom-4 right-4 z-[120]">
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className="flex items-center gap-2 rounded-full border border-gray-200 bg-white px-3 py-2 text-sm text-gray-800 shadow-lg transition-colors hover:bg-gray-50"
+            aria-label="Seasonal settings"
+          >
+            <Settings2 className="h-4 w-4" />
+            <span className="hidden sm:inline">Theme: {themeLabel}</span>
+            <span className="hidden sm:inline">Snow: {snowLabel}</span>
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" sideOffset={8}>
+          <DropdownMenuLabel>Seasonal settings</DropdownMenuLabel>
+          <DropdownMenuSeparator />
+          <DropdownMenuLabel className="text-xs font-medium opacity-80">
+            Theme
+          </DropdownMenuLabel>
+          <DropdownMenuRadioGroup
+            value={themeMode}
+            onValueChange={(v) => setThemeMode(v as SeasonalThemeMode)}
+          >
+            <DropdownMenuRadioItem value="auto">Auto</DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="default">
+              Default
+            </DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="christmas">
+              Christmas
+            </DropdownMenuRadioItem>
+          </DropdownMenuRadioGroup>
+          <DropdownMenuSeparator />
+          <DropdownMenuLabel className="text-xs font-medium opacity-80">
+            Snow
+          </DropdownMenuLabel>
+          <DropdownMenuRadioGroup
+            value={snowMode}
+            onValueChange={(v) => setSnowMode(v as SeasonalSnowMode)}
+          >
+            <DropdownMenuRadioItem value="auto">Auto</DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="on">On</DropdownMenuRadioItem>
+            <DropdownMenuRadioItem value="off">Off</DropdownMenuRadioItem>
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+};

--- a/src/components/SeasonalEffects.tsx
+++ b/src/components/SeasonalEffects.tsx
@@ -1,15 +1,48 @@
 'use client';
 
+import { useEffect, useState } from 'react';
 import { Snow } from '@/components/Snow';
 import { getSeasonalThemeWithMode } from '@/lib/seasonalTheme';
 import { useSeasonalPreferences } from '@/hooks/useSeasonalPreferences';
 
+type LegacyMediaQueryList = {
+  addListener?: (listener: () => void) => void;
+  removeListener?: (listener: () => void) => void;
+};
+
 export const SeasonalEffects = () => {
   const { themeMode, snowMode } = useSeasonalPreferences();
+  const [prefersReducedMotion, setPrefersReducedMotion] = useState(false);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+
+    const mediaQuery = window.matchMedia('(prefers-reduced-motion: reduce)');
+
+    const update = () => {
+      setPrefersReducedMotion(mediaQuery.matches);
+    };
+
+    update();
+
+    if (typeof mediaQuery.addEventListener === 'function') {
+      mediaQuery.addEventListener('change', update);
+      return () => {
+        mediaQuery.removeEventListener('change', update);
+      };
+    }
+
+    const legacyMediaQuery = mediaQuery as unknown as LegacyMediaQueryList;
+    legacyMediaQuery.addListener?.(update);
+    return () => {
+      legacyMediaQuery.removeListener?.(update);
+    };
+  }, []);
+
   const seasonal = getSeasonalThemeWithMode(new Date(), themeMode);
 
   const enableSnow =
     snowMode === 'on' ? true : snowMode === 'off' ? false : seasonal.enableSnow;
 
-  return <>{enableSnow ? <Snow /> : null}</>;
+  return <>{!prefersReducedMotion && enableSnow ? <Snow /> : null}</>;
 };

--- a/src/components/SeasonalEffects.tsx
+++ b/src/components/SeasonalEffects.tsx
@@ -1,0 +1,15 @@
+'use client';
+
+import { Snow } from '@/components/Snow';
+import { getSeasonalThemeWithMode } from '@/lib/seasonalTheme';
+import { useSeasonalPreferences } from '@/hooks/useSeasonalPreferences';
+
+export const SeasonalEffects = () => {
+  const { themeMode, snowMode } = useSeasonalPreferences();
+  const seasonal = getSeasonalThemeWithMode(new Date(), themeMode);
+
+  const enableSnow =
+    snowMode === 'on' ? true : snowMode === 'off' ? false : seasonal.enableSnow;
+
+  return <>{enableSnow ? <Snow /> : null}</>;
+};

--- a/src/hooks/useSeasonalPreferences.ts
+++ b/src/hooks/useSeasonalPreferences.ts
@@ -1,0 +1,92 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import type { SeasonalThemeMode } from '@/lib/seasonalTheme';
+
+export type SeasonalSnowMode = 'auto' | 'on' | 'off';
+
+type SeasonalPreferences = {
+  themeMode: SeasonalThemeMode;
+  snowMode: SeasonalSnowMode;
+};
+
+const THEME_MODE_KEY = 'meetjs_seasonal_theme_mode';
+const SNOW_MODE_KEY = 'meetjs_seasonal_snow_mode';
+const CHANGE_EVENT = 'meetjs-seasonal-preferences-changed';
+
+const readThemeMode = (): SeasonalThemeMode => {
+  if (typeof window === 'undefined') return 'auto';
+  const value = window.localStorage.getItem(THEME_MODE_KEY);
+  if (value === 'default' || value === 'christmas' || value === 'auto') {
+    return value;
+  }
+  return 'auto';
+};
+
+const readSnowMode = (): SeasonalSnowMode => {
+  if (typeof window === 'undefined') return 'auto';
+  const value = window.localStorage.getItem(SNOW_MODE_KEY);
+  if (value === 'on' || value === 'off' || value === 'auto') {
+    return value;
+  }
+  return 'auto';
+};
+
+const emitChange = () => {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new Event(CHANGE_EVENT));
+};
+
+export const useSeasonalPreferences = (): SeasonalPreferences & {
+  setThemeMode: (mode: SeasonalThemeMode) => void;
+  setSnowMode: (mode: SeasonalSnowMode) => void;
+} => {
+  const [themeMode, setThemeModeState] = useState<SeasonalThemeMode>(() =>
+    readThemeMode(),
+  );
+  const [snowMode, setSnowModeState] = useState<SeasonalSnowMode>(() =>
+    readSnowMode(),
+  );
+
+  useEffect(() => {
+    const sync = () => {
+      setThemeModeState(readThemeMode());
+      setSnowModeState(readSnowMode());
+    };
+
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === THEME_MODE_KEY || e.key === SNOW_MODE_KEY) {
+        sync();
+      }
+    };
+
+    window.addEventListener('storage', onStorage);
+    window.addEventListener(CHANGE_EVENT, sync);
+
+    return () => {
+      window.removeEventListener('storage', onStorage);
+      window.removeEventListener(CHANGE_EVENT, sync);
+    };
+  }, []);
+
+  const setThemeMode = useCallback((mode: SeasonalThemeMode) => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(THEME_MODE_KEY, mode);
+    setThemeModeState(mode);
+    emitChange();
+  }, []);
+
+  const setSnowMode = useCallback((mode: SeasonalSnowMode) => {
+    if (typeof window === 'undefined') return;
+    window.localStorage.setItem(SNOW_MODE_KEY, mode);
+    setSnowModeState(mode);
+    emitChange();
+  }, []);
+
+  return {
+    themeMode,
+    snowMode,
+    setThemeMode,
+    setSnowMode,
+  };
+};

--- a/src/lib/seasonalTheme.ts
+++ b/src/lib/seasonalTheme.ts
@@ -3,6 +3,8 @@ export type SeasonalTheme = {
   enableSnow: boolean;
 };
 
+export type SeasonalThemeMode = 'auto' | 'default' | 'christmas';
+
 const isChristmasSeason = (date: Date) => {
   const month = date.getMonth();
   const day = date.getDate();
@@ -22,4 +24,25 @@ export const getSeasonalTheme = (date: Date = new Date()): SeasonalTheme => {
     logoSrc: '/logo.svg',
     enableSnow: false,
   };
+};
+
+export const getSeasonalThemeWithMode = (
+  date: Date = new Date(),
+  mode: SeasonalThemeMode = 'auto',
+): SeasonalTheme => {
+  if (mode === 'christmas') {
+    return {
+      logoSrc: '/christmas_logo.svg',
+      enableSnow: true,
+    };
+  }
+
+  if (mode === 'default') {
+    return {
+      logoSrc: '/logo.svg',
+      enableSnow: false,
+    };
+  }
+
+  return getSeasonalTheme(date);
 };

--- a/src/lib/seasonalTheme.ts
+++ b/src/lib/seasonalTheme.ts
@@ -1,0 +1,25 @@
+export type SeasonalTheme = {
+  logoSrc: string;
+  enableSnow: boolean;
+};
+
+const isChristmasSeason = (date: Date) => {
+  const month = date.getMonth();
+  const day = date.getDate();
+
+  return month === 11 || (month === 0 && day <= 15);
+};
+
+export const getSeasonalTheme = (date: Date = new Date()): SeasonalTheme => {
+  if (isChristmasSeason(date)) {
+    return {
+      logoSrc: '/christmas_logo.svg',
+      enableSnow: true,
+    };
+  }
+
+  return {
+    logoSrc: '/logo.svg',
+    enableSnow: false,
+  };
+};


### PR DESCRIPTION
<img width="371" height="483" alt="Screenshot 2025-12-30 at 12 01 11" src="https://github.com/user-attachments/assets/2b45fe0f-5bf7-450f-85ab-c21d6b5f1ad9" />
