### PR TITLE
feat(2025-review): add 2025 Year in Review page with stats and highlights

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -311,6 +311,7 @@
   },
   "hello_world": "Hello World",
   "hero": {
+    "2025_wrapped": "2025 Wrapped",
     "cta": "Find Your Local Meetup",
     "follow_us": "Follow us",
     "join_discord": "Join Discord",
@@ -336,6 +337,7 @@
     "contact": "Contact",
     "discounts": "Discounts",
     "dropdown": {
+      "2025_review": "🎆 2025 Wrapped",
       "about_meetjs": "About meet.js",
       "all_cities": "All Cities",
       "all_discounts": "All Discounts",
@@ -356,6 +358,7 @@
     "home": "Home",
     "menu_items": {
       "14_birthday": "14 birthday",
+      "2025_review": "🎆 2025 Wrapped",
       "30_years_js": "\uD83C\uDF89 30 Years of JS",
       "about": "about",
       "brand_assets": "brand assets",

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -311,6 +311,7 @@
   },
   "hello_world": "Witaj świecie",
   "hero": {
+    "2025_wrapped": "2025 Wrapped",
     "cta": "Znajdź Swój Lokalny Meetup",
     "follow_us": "Śledź nas",
     "join_discord": "Dołącz do Discord",
@@ -336,6 +337,7 @@
     "contact": "Kontakt",
     "discounts": "Zniżki",
     "dropdown": {
+      "2025_review": "🎆 2025 Wrapped",
       "about_meetjs": "O meet.js",
       "all_cities": "Wszystkie miasta",
       "all_discounts": "Wszystkie zniżki",
@@ -356,6 +358,7 @@
     "home": "Strona główna",
     "menu_items": {
       "14_birthday": "14 urodziny",
+      "2025_review": "🎆 2025 Wrapped",
       "30_years_js": "\uD83C\uDF89 30 lat JS",
       "about": "o nas",
       "brand_assets": "logo i kolory",

--- a/src/app/(pages)/2025-review/layout.tsx
+++ b/src/app/(pages)/2025-review/layout.tsx
@@ -1,0 +1,23 @@
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: '2025 Year in Review | meet.js',
+  description:
+    "Frontend, JavaScript, and TypeScript Year in Review 2025. The year we survived another framework explosion, embraced AI, and still couldn't center a div without Googling it.",
+  openGraph: {
+    title: '2025 Year in Review | meet.js',
+    description:
+      'Frontend, JavaScript, and TypeScript Year in Review 2025. Stats, highlights, and predictions for 2026!',
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: '2025 Year in Review | meet.js',
+    description:
+      'Frontend, JavaScript, and TypeScript Year in Review 2025. Stats, highlights, and predictions for 2026!',
+  },
+};
+
+export default function Layout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/src/app/(pages)/2025-review/page.tsx
+++ b/src/app/(pages)/2025-review/page.tsx
@@ -1,0 +1,517 @@
+'use client';
+
+import Link from 'next/link';
+import { useState } from 'react';
+
+const stats = [
+  {
+    number: '0',
+    label: 'New JS Frameworks',
+    description: 'Finally, a year of peace! (just kidding, there were 47)',
+    emoji: '🎉',
+  },
+  {
+    number: '47',
+    label: 'Actually New Frameworks',
+    description: 'We lied. The JS ecosystem never sleeps.',
+    emoji: '😅',
+  },
+  {
+    number: '∞',
+    label: 'node_modules Size',
+    description: 'Still heavier than a black hole',
+    emoji: '📦',
+  },
+  {
+    number: '99%',
+    label: 'Devs Using TypeScript',
+    description: 'The 1% are still debugging their any types',
+    emoji: '💙',
+  },
+];
+
+const goodThings = [
+  {
+    title: 'TypeScript 5.5+ Improvements',
+    description:
+      'Inferred type predicates, isolated declarations, and faster compilation. TypeScript keeps getting better!',
+    emoji: '🚀',
+  },
+  {
+    title: 'React 19 Stable',
+    description:
+      'Server Components, Actions, and use() hook finally stable. The future is here!',
+    emoji: '⚛️',
+  },
+  {
+    title: 'Bun 1.x Maturity',
+    description:
+      'Bun became a serious contender. npm install in 0.3 seconds? Yes please!',
+    emoji: '🥟',
+  },
+  {
+    title: 'CSS Container Queries',
+    description:
+      'Finally mainstream! Responsive components without JavaScript hacks.',
+    emoji: '🎨',
+  },
+  {
+    title: 'AI Coding Assistants',
+    description:
+      'Copilot, Cursor, Windsurf... We write prompts now, not code. Wait, is that good?',
+    emoji: '🤖',
+  },
+  {
+    title: 'Vite Dominance',
+    description: 'Webpack who? Vite became the default for everything.',
+    emoji: '⚡',
+  },
+];
+
+const badThings = [
+  {
+    title: 'npm Package Drama',
+    description:
+      'Another year, another supply chain attack. Left-pad PTSD intensifies.',
+    emoji: '😰',
+  },
+  {
+    title: 'Framework Fatigue',
+    description:
+      'Do I use Next.js, Remix, Astro, SvelteKit, Nuxt, or... *passes out*',
+    emoji: '😵',
+  },
+  {
+    title: 'AI-Generated Bugs',
+    description:
+      'Copy-pasting AI code without understanding it. What could go wrong?',
+    emoji: '🐛',
+  },
+  {
+    title: 'The Great Layoffs',
+    description:
+      "Tech industry had a rough year. We're all in this together. 💪",
+    emoji: '📉',
+  },
+  {
+    title: 'Still No Native Enums in JS',
+    description:
+      'Year 30 of JavaScript. Still using objects as enums. Cool cool cool.',
+    emoji: '🤷',
+  },
+  {
+    title: 'Tailwind vs CSS Debates',
+    description:
+      'The war continues. Friendships were lost. CSS purists remain salty.',
+    emoji: '⚔️',
+  },
+];
+
+const funnyStats = [
+  { stat: '2,847', label: 'Hours spent configuring ESLint', emoji: '⚙️' },
+  {
+    stat: '156',
+    label: 'Times you said "it works on my machine"',
+    emoji: '💻',
+  },
+  { stat: '89', label: 'Abandoned side projects', emoji: '🗑️' },
+  { stat: '12', label: 'Times you actually read the docs', emoji: '📚' },
+  { stat: '∞', label: 'Console.logs still in production', emoji: '🪲' },
+  { stat: '1', label: 'Time you understood regex', emoji: '🧙' },
+  { stat: '0', label: 'CSS files without !important', emoji: '🎨' },
+  { stat: '42', label: 'Tabs vs Spaces arguments', emoji: '⌨️' },
+];
+
+const predictions2026 = [
+  'React will release version 20, 21, and 22 in the same week',
+  'Someone will create a framework that compiles to another framework',
+  'AI will write 90% of code, developers will spend 90% debugging it',
+  'TypeScript will add a "super-strict" mode that rejects all code',
+  'node_modules will finally exceed the storage capacity of the observable universe',
+  'A new JavaScript runtime written in Rust will appear (again)',
+  'CSS will get a feature that Sass had 10 years ago',
+  'Someone will port Doom to run inside a React component',
+];
+
+const shareText = `🎉 2025 Frontend Year in Review!
+
+The year we got 47 new frameworks (we counted), TypeScript hit 99% adoption, and node_modules still weighs more than a black hole.
+
+Check out the full recap at meetjs.pl/2025-review
+
+#JavaScript #TypeScript #Frontend #WebDev #2025Wrapped`;
+
+function ShareButton({
+  platform,
+  onClick,
+  children,
+}: {
+  platform: string;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      className={`rounded-full px-6 py-3 font-semibold text-white transition-all duration-300 hover:scale-105 ${platform === 'twitter' ? 'bg-black hover:bg-gray-800' : ''} ${platform === 'linkedin' ? 'bg-[#0A66C2] hover:bg-[#004182]' : ''} ${platform === 'facebook' ? 'bg-[#1877F2] hover:bg-[#0d65d9]' : ''} `}
+    >
+      {children}
+    </button>
+  );
+}
+
+export default function YearInReview2025() {
+  const [randomPrediction, setRandomPrediction] = useState(
+    () => predictions2026[Math.floor(Math.random() * predictions2026.length)],
+  );
+
+  const shareOnTwitter = () => {
+    const url = encodeURIComponent('https://meetjs.pl/2025-review');
+    const text = encodeURIComponent(shareText);
+    window.open(
+      `https://twitter.com/intent/tweet?text=${text}&url=${url}`,
+      '_blank',
+    );
+  };
+
+  const shareOnLinkedIn = () => {
+    const url = encodeURIComponent('https://meetjs.pl/2025-review');
+    window.open(
+      `https://www.linkedin.com/sharing/share-offsite/?url=${url}`,
+      '_blank',
+    );
+  };
+
+  const shareOnFacebook = () => {
+    const url = encodeURIComponent('https://meetjs.pl/2025-review');
+    window.open(
+      `https://www.facebook.com/sharer/sharer.php?u=${url}`,
+      '_blank',
+    );
+  };
+
+  return (
+    <>
+      <main>
+        {/* Hero Section */}
+        <section className="relative overflow-hidden bg-gradient-to-br from-purple-600 via-pink-500 to-orange-400 py-24">
+          <div className="absolute inset-0 bg-black/10"></div>
+          <div className="absolute left-0 top-0 h-full w-full">
+            <div className="absolute left-10 top-10 h-20 w-20 animate-pulse rounded-full bg-white/10"></div>
+            <div className="absolute right-20 top-32 h-16 w-16 animate-pulse rounded-full bg-white/10 delay-300"></div>
+            <div className="absolute bottom-20 left-1/4 h-12 w-12 animate-pulse rounded-full bg-white/10 delay-700"></div>
+            <div className="absolute bottom-32 right-1/3 h-24 w-24 animate-pulse rounded-full bg-white/10 delay-500"></div>
+            <div className="absolute right-10 top-1/2 text-6xl opacity-20">
+              🎊
+            </div>
+            <div className="absolute left-1/4 top-20 text-4xl opacity-20">
+              ✨
+            </div>
+            <div className="absolute bottom-10 right-1/4 text-5xl opacity-20">
+              🚀
+            </div>
+          </div>
+          <div className="container relative z-10 mx-auto px-4 text-center">
+            <div className="mb-6">
+              <span className="mb-4 inline-block animate-bounce text-7xl">
+                🎆
+              </span>
+            </div>
+            <h1 className="mb-6 text-5xl font-bold leading-tight text-white md:text-7xl">
+              2025
+              <span className="block bg-gradient-to-r from-yellow-300 via-white to-yellow-300 bg-clip-text text-transparent">
+                Year in Review
+              </span>
+            </h1>
+            <p className="mx-auto mb-4 max-w-3xl text-xl leading-relaxed text-white/90 md:text-2xl">
+              Frontend / JavaScript / TypeScript
+            </p>
+            <p className="mx-auto mb-8 max-w-2xl text-lg text-white/80">
+              The year we survived another framework explosion, embraced AI
+              overlords, and still couldn&apos;t center a div without Googling
+              it.
+            </p>
+            <div className="flex flex-wrap justify-center gap-4">
+              <Link
+                href="#stats"
+                className="group rounded-full bg-white px-8 py-4 font-medium text-purple-600 transition-all duration-300 hover:scale-105 hover:shadow-lg"
+              >
+                <span className="flex items-center gap-2">
+                  See the Numbers
+                  <span className="transition-transform group-hover:translate-y-1">
+                    ↓
+                  </span>
+                </span>
+              </Link>
+            </div>
+          </div>
+        </section>
+
+        {/* Main Stats */}
+        <section id="stats" className="bg-gray-900 py-20">
+          <div className="container mx-auto px-4">
+            <div className="mb-16 text-center">
+              <h2 className="mb-4 text-3xl font-bold text-white md:text-4xl">
+                The Numbers That Matter*
+              </h2>
+              <p className="text-gray-400">*Totally accurate, trust us</p>
+            </div>
+            <div className="grid grid-cols-1 gap-8 md:grid-cols-2 lg:grid-cols-4">
+              {stats.map((stat, index) => (
+                <div
+                  key={index}
+                  className="group rounded-2xl bg-gradient-to-br from-gray-800 to-gray-900 p-6 text-center transition-all duration-300 hover:scale-105 hover:shadow-xl hover:shadow-purple-500/20"
+                >
+                  <div className="mb-2 text-4xl">{stat.emoji}</div>
+                  <div className="mb-2 bg-gradient-to-r from-yellow-400 to-orange-500 bg-clip-text text-5xl font-bold text-transparent">
+                    {stat.number}
+                  </div>
+                  <div className="mb-2 text-lg font-semibold text-white">
+                    {stat.label}
+                  </div>
+                  <p className="text-sm text-gray-400">{stat.description}</p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Your Year in Numbers (Funny) */}
+        <section className="bg-gradient-to-br from-blue-900 to-purple-900 py-20">
+          <div className="container mx-auto px-4">
+            <div className="mb-16 text-center">
+              <h2 className="mb-4 text-3xl font-bold text-white md:text-4xl">
+                Your 2025 as a Developer
+              </h2>
+              <p className="text-blue-200">
+                Based on extensive research (we made it up)
+              </p>
+            </div>
+            <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+              {funnyStats.map((item, index) => (
+                <div
+                  key={index}
+                  className="rounded-xl bg-white/10 p-4 text-center backdrop-blur-sm transition-all duration-300 hover:bg-white/20"
+                >
+                  <div className="mb-2 text-3xl">{item.emoji}</div>
+                  <div className="text-2xl font-bold text-white">
+                    {item.stat}
+                  </div>
+                  <div className="text-sm text-blue-200">{item.label}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Good Things */}
+        <section className="bg-gradient-to-br from-green-50 to-emerald-100 py-20 dark:from-green-900/20 dark:to-emerald-900/20">
+          <div className="container mx-auto px-4">
+            <div className="mb-16 text-center">
+              <span className="mb-4 inline-block text-5xl">🌟</span>
+              <h2 className="mb-4 text-3xl font-bold text-gray-900 md:text-4xl dark:text-white">
+                The Good Stuff
+              </h2>
+              <p className="text-gray-600 dark:text-gray-300">
+                Things that made us happy in 2025
+              </p>
+            </div>
+            <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+              {goodThings.map((item, index) => (
+                <div
+                  key={index}
+                  className="rounded-2xl border border-green-200 bg-white p-6 shadow-sm transition-all duration-300 hover:scale-105 hover:shadow-lg dark:border-green-800 dark:bg-gray-800"
+                >
+                  <div className="mb-3 text-3xl">{item.emoji}</div>
+                  <h3 className="mb-2 text-xl font-semibold text-gray-900 dark:text-white">
+                    {item.title}
+                  </h3>
+                  <p className="text-gray-600 dark:text-gray-300">
+                    {item.description}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Bad Things */}
+        <section className="bg-gradient-to-br from-red-50 to-orange-100 py-20 dark:from-red-900/20 dark:to-orange-900/20">
+          <div className="container mx-auto px-4">
+            <div className="mb-16 text-center">
+              <span className="mb-4 inline-block text-5xl">😬</span>
+              <h2 className="mb-4 text-3xl font-bold text-gray-900 md:text-4xl dark:text-white">
+                The Not-So-Good Stuff
+              </h2>
+              <p className="text-gray-600 dark:text-gray-300">
+                Things we&apos;d rather forget
+              </p>
+            </div>
+            <div className="grid grid-cols-1 gap-6 md:grid-cols-2 lg:grid-cols-3">
+              {badThings.map((item, index) => (
+                <div
+                  key={index}
+                  className="rounded-2xl border border-red-200 bg-white p-6 shadow-sm transition-all duration-300 hover:scale-105 hover:shadow-lg dark:border-red-800 dark:bg-gray-800"
+                >
+                  <div className="mb-3 text-3xl">{item.emoji}</div>
+                  <h3 className="mb-2 text-xl font-semibold text-gray-900 dark:text-white">
+                    {item.title}
+                  </h3>
+                  <p className="text-gray-600 dark:text-gray-300">
+                    {item.description}
+                  </p>
+                </div>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {/* Framework Counter */}
+        <section className="bg-gray-900 py-20">
+          <div className="container mx-auto px-4">
+            <div className="mx-auto max-w-4xl text-center">
+              <h2 className="mb-8 text-3xl font-bold text-white md:text-4xl">
+                🏆 Framework of the Year Award
+              </h2>
+              <div className="mb-8 rounded-2xl bg-gradient-to-r from-yellow-500 via-yellow-400 to-yellow-500 p-8">
+                <div className="text-6xl font-bold text-gray-900">???</div>
+                <p className="mt-4 text-xl text-gray-800">
+                  We couldn&apos;t decide. There were too many.
+                </p>
+              </div>
+              <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
+                <div className="rounded-xl bg-gray-800 p-4">
+                  <div className="text-2xl font-bold text-blue-400">React</div>
+                  <div className="text-sm text-gray-400">Still king 👑</div>
+                </div>
+                <div className="rounded-xl bg-gray-800 p-4">
+                  <div className="text-2xl font-bold text-green-400">Vue</div>
+                  <div className="text-sm text-gray-400">Quietly winning</div>
+                </div>
+                <div className="rounded-xl bg-gray-800 p-4">
+                  <div className="text-2xl font-bold text-orange-400">
+                    Svelte
+                  </div>
+                  <div className="text-sm text-gray-400">The cool kid</div>
+                </div>
+                <div className="rounded-xl bg-gray-800 p-4">
+                  <div className="text-2xl font-bold text-purple-400">
+                    Solid
+                  </div>
+                  <div className="text-sm text-gray-400">Rising star</div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* 2026 Predictions */}
+        <section className="bg-gradient-to-br from-indigo-900 via-purple-900 to-pink-900 py-20">
+          <div className="container mx-auto px-4">
+            <div className="mx-auto max-w-3xl text-center">
+              <span className="mb-4 inline-block text-5xl">🔮</span>
+              <h2 className="mb-4 text-3xl font-bold text-white md:text-4xl">
+                2026 Prediction
+              </h2>
+              <p className="mb-8 text-purple-200">Our crystal ball says...</p>
+              <div className="rounded-2xl bg-white/10 p-8 backdrop-blur-sm">
+                <p className="text-xl italic text-white md:text-2xl">
+                  &ldquo;{randomPrediction}&rdquo;
+                </p>
+              </div>
+              <button
+                onClick={() =>
+                  setRandomPrediction(
+                    predictions2026[
+                      Math.floor(Math.random() * predictions2026.length)
+                    ],
+                  )
+                }
+                className="mt-6 rounded-full bg-white/20 px-6 py-3 text-white transition-all duration-300 hover:bg-white/30"
+              >
+                🎲 Get Another Prediction
+              </button>
+            </div>
+          </div>
+        </section>
+
+        {/* TypeScript Love */}
+        <section className="bg-[#3178c6] py-20">
+          <div className="container mx-auto px-4 text-center">
+            <div className="mx-auto max-w-3xl">
+              <span className="mb-4 inline-block text-6xl">💙</span>
+              <h2 className="mb-6 text-3xl font-bold text-white md:text-4xl">
+                TypeScript Appreciation Corner
+              </h2>
+              <p className="mb-8 text-xl text-blue-100">
+                Thank you, TypeScript, for catching our bugs before production.
+                <br />
+                <span className="text-blue-200">Most of them, anyway.</span>
+              </p>
+              <div className="rounded-xl bg-white/10 p-6 text-left font-mono text-sm text-blue-100">
+                <pre>{`// 2025 mood
+type Developer = {
+  coffee: "always" | "more";
+  bugs: number; // always > 0
+  imposterSyndrome: true;
+  lovesTypeScript: true;
+};`}</pre>
+              </div>
+            </div>
+          </div>
+        </section>
+
+        {/* Share Section */}
+        <section className="bg-gradient-to-r from-gray-900 to-gray-800 py-20">
+          <div className="container mx-auto px-4 text-center">
+            <h2 className="mb-6 text-3xl font-bold text-white md:text-4xl">
+              Share Your 2025! 🎉
+            </h2>
+            <p className="mx-auto mb-8 max-w-2xl text-lg text-gray-300">
+              Survived another year of JavaScript? Share the celebration with
+              your fellow devs!
+            </p>
+            <div className="flex flex-wrap justify-center gap-4">
+              <ShareButton platform="twitter" onClick={shareOnTwitter}>
+                𝕏 Share on X
+              </ShareButton>
+              <ShareButton platform="linkedin" onClick={shareOnLinkedIn}>
+                Share on LinkedIn
+              </ShareButton>
+              <ShareButton platform="facebook" onClick={shareOnFacebook}>
+                Share on Facebook
+              </ShareButton>
+            </div>
+          </div>
+        </section>
+
+        {/* CTA */}
+        <section className="bg-gradient-to-br from-yellow-400 via-yellow-500 to-orange-500 py-20">
+          <div className="container mx-auto px-4 text-center">
+            <h2 className="mb-6 text-3xl font-bold text-gray-900 md:text-4xl">
+              Here&apos;s to 2026! 🥂
+            </h2>
+            <p className="mx-auto mb-8 max-w-2xl text-lg text-gray-800">
+              May your builds be fast, your types be strict, and your
+              node_modules be... well, let&apos;s not talk about node_modules.
+            </p>
+            <div className="flex flex-wrap justify-center gap-4">
+              <Link
+                href="/events"
+                className="rounded-full bg-gray-900 px-8 py-4 font-medium text-white transition-all duration-300 hover:scale-105 hover:bg-gray-800"
+              >
+                Find a Meetup Near You
+              </Link>
+              <Link
+                href="/"
+                className="rounded-full bg-white/30 px-8 py-4 font-medium text-gray-900 backdrop-blur-sm transition-all duration-300 hover:scale-105 hover:bg-white/50"
+              >
+                Back to Homepage
+              </Link>
+            </div>
+          </div>
+        </section>
+      </main>
+    </>
+  );
+}

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,7 +1,9 @@
 import { RankingBanner } from '@/components/RankingBanner';
 import { AwardNomination } from '@/components/AwardNomination';
-import { Instagram, MessagesSquare } from 'lucide-react';
+import { Instagram, MessagesSquare, Sparkles } from 'lucide-react';
 import { getTranslate } from '@/tolgee/server';
+import Link from 'next/link';
+import type { Route } from 'next';
 
 export const HeroSection = async () => {
   const t = await getTranslate();
@@ -20,7 +22,20 @@ export const HeroSection = async () => {
         </h1>
         <h2 className="p-4 text-xl font-medium">{t('hero.subtitle')}</h2>
 
-        <div className="mt-6 flex justify-center gap-4">
+        {/* 2025 Wrapped - Standalone prominent button */}
+        <div className="mt-6">
+          <Link
+            href={'/2025-review' as Route}
+            className="inline-flex animate-[pulse-scale_2s_ease-in-out_infinite] items-center gap-2 rounded-full bg-gradient-to-r from-purple-500 via-pink-500 to-orange-400 px-6 py-3 text-base font-bold shadow-lg shadow-purple-500/30 transition-all hover:scale-110 hover:animate-none hover:shadow-xl hover:shadow-pink-500/40"
+          >
+            <Sparkles className="h-5 w-5" />
+            {t('hero.2025_wrapped')}
+            <span className="ml-1">→</span>
+          </Link>
+        </div>
+
+        {/* Social links - separate row */}
+        <div className="mt-4 flex flex-wrap justify-center gap-3">
           <a
             href="https://instagram.com/meet.js_poland"
             target="_blank"

--- a/src/components/Navigation/DesktopNavigation.tsx
+++ b/src/components/Navigation/DesktopNavigation.tsx
@@ -122,12 +122,14 @@ export const DesktopNavigation = () => {
                 current={item.current}
                 external={true}
                 name={item.name}
+                highlight={item.highlight}
               />
             ) : (
               <NavigationLink
                 href={item.href as Route}
                 current={item.current}
                 name={item.name}
+                highlight={item.highlight}
               />
             )}
           </li>

--- a/src/components/Navigation/MobileNavigation.tsx
+++ b/src/components/Navigation/MobileNavigation.tsx
@@ -138,9 +138,11 @@ export const MobileNavigation = () => {
                     as="a"
                     href={item.href}
                     className={classNames(
-                      item.current
-                        ? 'bg-gray-900 text-white'
-                        : 'text-gray-300 hover:bg-gray-700 hover:text-white',
+                      item.highlight
+                        ? 'bg-gradient-to-r from-purple-500 via-pink-500 to-orange-400 text-white shadow-lg'
+                        : item.current
+                          ? 'bg-gray-900 text-white'
+                          : 'text-gray-300 hover:bg-gray-700 hover:text-white',
                       'block rounded-md px-3 py-2 text-base font-medium',
                     )}
                     aria-current={item.current ? 'page' : undefined}

--- a/src/components/Navigation/NavigationLink.tsx
+++ b/src/components/Navigation/NavigationLink.tsx
@@ -8,6 +8,7 @@ type InternalNavLinkProps = {
   href: Route;
   current?: boolean;
   external?: false;
+  highlight?: boolean;
 };
 
 type ExternalNavLinkProps = {
@@ -15,6 +16,7 @@ type ExternalNavLinkProps = {
   href: string;
   current?: boolean;
   external: true;
+  highlight?: boolean;
 };
 
 type NavigationLinkProps = InternalNavLinkProps | ExternalNavLinkProps;
@@ -24,16 +26,18 @@ export const NavigationLink = ({
   href,
   current = false,
   external,
+  highlight = false,
 }: NavigationLinkProps) => {
+  const baseClasses = highlight
+    ? 'bg-gradient-to-r from-purple-500 via-pink-500 to-orange-400 text-white hover:from-purple-600 hover:via-pink-600 hover:to-orange-500 shadow-lg hover:shadow-xl hover:scale-105 transition-all duration-300'
+    : current
+      ? 'bg-gray-900 text-white'
+      : 'text-white hover:bg-green/80 hover:text-purple';
+
   return external ? (
     <a
       href={href}
-      className={classNames(
-        current
-          ? 'bg-gray-900 text-white'
-          : 'text-white hover:bg-green/80 hover:text-purple',
-        'rounded-md px-3 py-2 font-medium',
-      )}
+      className={classNames(baseClasses, 'rounded-md px-3 py-2 font-medium')}
       aria-current={current ? 'page' : undefined}
       target="_blank"
       rel="noopener noreferrer"
@@ -49,12 +53,7 @@ export const NavigationLink = ({
   ) : (
     <Link
       href={href}
-      className={classNames(
-        current
-          ? 'bg-gray-900 text-white'
-          : 'text-white hover:bg-green/80 hover:text-purple',
-        'rounded-md px-3 py-2 font-medium',
-      )}
+      className={classNames(baseClasses, 'rounded-md px-3 py-2 font-medium')}
       aria-current={current ? 'page' : undefined}
       itemProp="url"
     >

--- a/src/content/menuLinks.tsx
+++ b/src/content/menuLinks.tsx
@@ -4,6 +4,7 @@ export interface MenuLink {
   current: boolean;
   external: boolean;
   dropdown?: DropdownItem[];
+  highlight?: boolean;
 }
 
 export interface DropdownItem {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -168,10 +168,15 @@ const config: Config = {
           from: { height: 'var(--radix-accordion-content-height)' },
           to: { height: '0' },
         },
+        'pulse-scale': {
+          '0%, 100%': { transform: 'scale(1)' },
+          '50%': { transform: 'scale(1.05)' },
+        },
       },
       animation: {
         'accordion-down': 'accordion-down 0.2s ease-out',
         'accordion-up': 'accordion-up 0.2s ease-out',
+        'pulse-scale': 'pulse-scale 2s ease-in-out infinite',
       },
     },
   },


### PR DESCRIPTION
- Add new /2025-review route with layout and metadata
- Create interactive year-in-review page with stats, good/bad highlights, and 2026 predictions
- Add translation keys for "2025 Wrapped" in English and Polish navigation
- Include social sharing buttons for Twitter, LinkedIn, and Facebook
- Add animated hero section with gradient backgrounds and particle effects
- Display funny developer stats (ESLint configs, console.logs


<img width="1240" height="879" alt="Screenshot 2025-12-30 at 16 25 07" src="https://github.com/user-attachments/assets/851eecbd-df65-4efa-9bd2-c2c9aed33528" />

<img width="1157" height="720" alt="Screenshot 2025-12-30 at 16 25 02" src="https://github.com/user-attachments/assets/d471a40c-4b07-477a-8977-08b7bdf560e1" />

