### PR TITLE
feat(events): add conference/summit filtering and visual distinction

### DIFF
--- a/messages/en.json
+++ b/messages/en.json
@@ -580,5 +580,10 @@
     "since": "since",
     "summits": "summits"
   },
+  "event_card": {
+    "conference": "Conference",
+    "register": "Register",
+    "rsvp": "RSVP"
+  },
   "welcome": "Welcome to meet.js"
 }

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -580,5 +580,10 @@
     "since": "od",
     "summits": "summitów"
   },
+  "event_card": {
+    "conference": "Konferencja",
+    "register": "Zarejestruj się",
+    "rsvp": "RSVP"
+  },
   "welcome": "Witamy w meet.js"
 }

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -2,12 +2,13 @@
 
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { buttonVariants } from '@/components/ui/button';
-import { FaClock, FaLocationDot } from 'react-icons/fa6';
+import { FaClock, FaLocationDot, FaMicrophoneLines } from 'react-icons/fa6';
 import type { EventType } from '@/types/event';
 import { cn } from '@/lib/utils';
 import { formatDistanceToNow } from 'date-fns';
-import { getEventWeekDay } from '@/utils/eventUtils';
+import { getEventWeekDay, isConferenceEvent } from '@/utils/eventUtils';
 import { useLocale } from '@/hooks/useLocale';
+import { useTranslate } from '@tolgee/react';
 
 interface EventCardProps {
   event: EventType;
@@ -15,6 +16,7 @@ interface EventCardProps {
 
 export const EventCard = ({ event }: EventCardProps) => {
   const { locale } = useLocale();
+  const { t } = useTranslate();
   const now = new Date();
   const [day, month, year] = event.date.split('.');
   const [hours, minutes] = event.time.split(':');
@@ -32,6 +34,8 @@ export const EventCard = ({ event }: EventCardProps) => {
     now.getMonth() === eventDate.getMonth() &&
     now.getFullYear() === eventDate.getFullYear();
 
+  const isConference = isConferenceEvent(event.type);
+
   return (
     <Card
       data-testid="event-card-wrapper"
@@ -41,6 +45,7 @@ export const EventCard = ({ event }: EventCardProps) => {
         isToday &&
           !isInProgress &&
           'border-2 border-yellow-500 dark:border-yellow-400',
+        isConference && 'border-2 border-amber-400 dark:border-amber-500',
       )}
     >
       <CardHeader>
@@ -55,6 +60,12 @@ export const EventCard = ({ event }: EventCardProps) => {
               {event.name}
             </a>
           </CardTitle>
+          {isConference && (
+            <div className="flex items-center gap-1 rounded-full bg-amber-100 px-2 py-1 text-xs font-medium text-amber-800 dark:bg-amber-900/50 dark:text-amber-200">
+              <FaMicrophoneLines className="h-3 w-3" />
+              {t('event_card.conference')}
+            </div>
+          )}
         </div>
         {eventDate.getTime() > 0 && (
           <p className="text-sm text-muted-foreground">
@@ -110,10 +121,12 @@ export const EventCard = ({ event }: EventCardProps) => {
                 buttonVariants({
                   size: 'sm',
                 }),
-                'bg-purple text-white transition-colors hover:bg-purple/90 dark:bg-green dark:hover:bg-green/90',
+                isConference
+                  ? 'bg-gradient-to-r from-amber-600 to-orange-600 text-white hover:from-amber-700 hover:to-orange-700 dark:from-amber-500 dark:to-orange-500 dark:hover:from-amber-600 dark:hover:to-orange-600'
+                  : 'bg-purple text-white transition-colors hover:bg-purple/90 dark:bg-green dark:hover:bg-green/90',
               )}
             >
-              RSVP
+              {isConference ? t('event_card.register') : t('event_card.rsvp')}
             </a>
           )}
         </div>

--- a/src/components/FeaturedEvents.tsx
+++ b/src/components/FeaturedEvents.tsx
@@ -11,9 +11,10 @@ import { EmptyEventsAlert } from '@/components/EmptyEventsAlert';
 import { getUpcomingEvents } from '@/utils/getUpcomingEvents';
 import { filterUpcomingEvents } from '@/utils/eventUtils';
 import { getTranslate } from '@/tolgee/server';
+import type { EventTypeName } from '@/types/event';
 
 export interface Event {
-  type: string;
+  type: EventTypeName;
   id: number;
   date_add: number;
   date: string;

--- a/src/components/FilterEvents.tsx
+++ b/src/components/FilterEvents.tsx
@@ -6,6 +6,7 @@ import { Suspense } from 'react';
 import { EventsList } from '@/components/EventsList';
 import Link from 'next/link';
 import { getTranslate } from '@/tolgee/server';
+import { isConferenceEvent } from '@/utils/eventUtils';
 
 interface FilterEventsProps {
   events: EventType[] | null;
@@ -27,9 +28,12 @@ const FilterEventsContent = async ({ events, filter }: FilterEventsProps) => {
     return <div>{t('events_page.filter.events_not_found')}</div>;
   }
 
-  const filteredEvents = filter
-    ? events.filter((event) => event.city === filter)
-    : events;
+  const filteredEvents =
+    filter === 'summit'
+      ? events.filter((event) => isConferenceEvent(event.type))
+      : filter
+        ? events.filter((event) => event.city === filter)
+        : events;
 
   return (
     <>
@@ -45,6 +49,20 @@ const FilterEventsContent = async ({ events, filter }: FilterEventsProps) => {
             className={linkClassNames(null)}
           >
             {t('events_page.filter.all')} ({events.length})
+          </Link>
+          <Link
+            href={{
+              pathname: '/events',
+              query: {
+                city: 'summit',
+              },
+            }}
+            replace
+            scroll={false}
+            className={linkClassNames('summit')}
+          >
+            🎤 Summit (
+            {events.filter((event) => isConferenceEvent(event.type)).length})
           </Link>
           <Link
             href={{

--- a/src/types/event.ts
+++ b/src/types/event.ts
@@ -1,12 +1,22 @@
 import { z } from 'zod';
 
+// Define the allowed event types
+export const EventTypeEnum = z.enum([
+  'Spotkanie',
+  'Konferencja',
+  'Meetup',
+  'Conference',
+  'Webinar',
+  'Warsztaty',
+]);
+
 const EventSchema = z.object({
   id: z.number(),
   date_add: z.number(),
   date: z.string(),
   time: z.string().default(''),
   name: z.string(),
-  type: z.string(),
+  type: EventTypeEnum,
   url: z.string(),
   rsvp: z.string(),
   city: z.string().default(''),
@@ -20,3 +30,4 @@ export const EventsSchema = z.record(z.string(), EventSchema).nullable();
 
 export type EventType = z.infer<typeof EventSchema>;
 export type EventsType = z.infer<typeof EventsSchema>;
+export type EventTypeName = z.infer<typeof EventTypeEnum>;

--- a/src/utils/eventUtils.ts
+++ b/src/utils/eventUtils.ts
@@ -1,4 +1,17 @@
-import type { EventType } from '@/types/event';
+import type { EventType, EventTypeName } from '@/types/event';
+import { EventTypeEnum } from '@/types/event';
+
+/**
+ * Type-safe function to check if event is a conference
+ * Uses EventTypeEnum values instead of hardcoded strings
+ */
+export const isConferenceEvent = (eventType: EventTypeName): boolean => {
+  const conferenceTypes: EventTypeName[] = [
+    EventTypeEnum.enum.Conference,
+    EventTypeEnum.enum.Konferencja,
+  ];
+  return conferenceTypes.includes(eventType);
+};
 
 /**
  * Parses a date string in DD.MM.YYYY format to a Date object


### PR DESCRIPTION
- Add event_card translation keys for conference badge, register, and RSVP buttons in English and Polish
- Add conference badge with microphone icon to EventCard for conference-type events
- Add amber border styling to distinguish conference events from regular meetups
- Add summit filter tab to FilterEvents showing conference count
- Update register button styling with amber-orange gradient for conferences
- Add EventTypeEnum with


<img width="901" height="556" alt="Screenshot 2026-01-23 at 13 41 23" src="https://github.com/user-attachments/assets/5502e857-d71d-4f48-975a-594fe5291c43" />
