### PR TITLE
feat: add speakers page and section

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,8 @@
 EVENTS_API_URL=http://localhost:3000/api/mocked/crossweb
 SITE_URL=http://localhost:3000
 DISCORD_SERVER_ID=735954756169760768
+SPEAKERS_API_URL=https://crossweb.pl/api/meetjs/speakers
+SPEAKERS_API_TOKEN=<your_crossweb_api_token>
 
 # Tolgee Configuration
 NEXT_PUBLIC_TOLGEE_API_KEY=<your_tolgee_api_key>

--- a/messages/en.json
+++ b/messages/en.json
@@ -382,6 +382,7 @@
       "code_of_conduct": "code of conduct",
       "discounts": "\uD83D\uDCB0 discounts",
       "summit": "summit",
+      "speakers": "\uD83C\uDFA4 speakers",
       "videos": "\uD83C\uDFA5 videos",
       "wdi_2025": "WDI 2025"
     },
@@ -615,10 +616,19 @@
     "description": "Join us for a full day of learning, networking, and inspiration at SGH Warsaw School of Economics",
     "language_note": "Event in English"
   },
-  "event_card": {
-    "conference": "Conference",
-    "register": "Register",
-    "rsvp": "RSVP"
+  "speaker_faces": {
+    "community_members": "speakers from the community",
+    "view_all": "See All Speakers"
+  },
+  "speakers_page": {
+    "meta_title": "Speakers - meet.js",
+    "meta_description": "All speakers who have presented at meet.js events across Poland.",
+    "page_title": "Speakers",
+    "subtitle": "All speakers who have presented at meet.js events",
+    "events_count": "Talks: {count}",
+    "view_profile": "View profile on Crossweb",
+    "no_speakers": "No speakers data available at the moment.",
+    "powered_by": "Speaker data provided by"
   },
   "welcome": "Welcome to meet.js"
 }

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -382,6 +382,7 @@
       "code_of_conduct": "kodeks postępowania",
       "discounts": "\uD83D\uDCB0 zniżki",
       "summit": "summit",
+      "speakers": "\uD83C\uDFA4 prelegenci",
       "videos": "\uD83C\uDFA5 wideo",
       "wdi_2025": "WDI 2025"
     },
@@ -615,10 +616,19 @@
     "description": "Dołącz do nas na cały dzień nauki, networkingu i inspiracji w SGH - Szkole Głównej Handlowej w Warszawie",
     "language_note": "Wydarzenie w języku angielskim"
   },
-  "event_card": {
-    "conference": "Konferencja",
-    "register": "Zarejestruj się",
-    "rsvp": "RSVP"
+  "speaker_faces": {
+    "community_members": "prelegentów z naszej społeczności",
+    "view_all": "Zobacz Wszystkich Prelegentów"
+  },
+  "speakers_page": {
+    "meta_title": "Prelegenci - meet.js",
+    "meta_description": "Wszyscy prelegenci, którzy wystąpili na wydarzeniach meet.js w Polsce.",
+    "page_title": "Prelegenci",
+    "subtitle": "Wszyscy prelegenci, którzy wystąpili na wydarzeniach meet.js",
+    "events_count": "Wystąpienia: {count}",
+    "view_profile": "Zobacz profil na Crossweb",
+    "no_speakers": "Brak danych o prelegentach w tej chwili.",
+    "powered_by": "Dane o prelegentach dostarcza"
   },
   "welcome": "Witamy w meet.js"
 }

--- a/next.config.ts
+++ b/next.config.ts
@@ -82,6 +82,10 @@ const nextConfig: NextConfig = {
         protocol: 'https',
         hostname: 'adventofcode.com',
       },
+      {
+        protocol: 'https',
+        hostname: 'crossweb.pl',
+      },
     ],
     // Next.js 16 defaults: minimumCacheTTL changed from 60s to 4 hours (14400s)
     // qualities default changed from [1..100] to [75]

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,6 +8,7 @@ import { HeroCarousel } from '@/components/HeroCarousel';
 import { PartnersSection } from '@/components/PartnersSection';
 import { CommunityParticipation } from '@/components/CommunityParticipationServer';
 import { YouTubeSubscribeBanner } from '@/components/YouTubeSubscribeBanner';
+import { SpeakerFaces } from '@/components/SpeakerFaces';
 
 export const dynamic = 'force-dynamic';
 
@@ -25,6 +26,7 @@ const Home = () => {
           <AboutSection />
           <Stats />
         </div>
+        <SpeakerFaces />
         <PartnersSection />
       </div>
       {/*<FloatingSummitCTA />*/}

--- a/src/app/speakers/page.tsx
+++ b/src/app/speakers/page.tsx
@@ -1,0 +1,95 @@
+import type { Metadata } from 'next';
+import Image from 'next/image';
+import { FaArrowUpRightFromSquare } from 'react-icons/fa6';
+import { getSpeakers } from '@/utils/getSpeakers';
+import { getTranslate } from '@/tolgee/server';
+
+export async function generateMetadata(): Promise<Metadata> {
+  const t = await getTranslate();
+
+  return {
+    title: t('speakers_page.meta_title'),
+    description: t('speakers_page.meta_description'),
+  };
+}
+
+const SpeakersPage = async () => {
+  const speakers = await getSpeakers();
+  const t = await getTranslate();
+
+  return (
+    <main className="mx-auto flex min-h-screen max-w-7xl flex-col items-center gap-6 p-5 px-5 sm:px-6 lg:px-8">
+      <section className="flex w-full flex-col items-center justify-center gap-6">
+        <h1 className="py-4 text-4xl font-bold">
+          {t('speakers_page.page_title')}
+        </h1>
+        <p className="text-center text-lg text-gray-600">
+          {t('speakers_page.subtitle')}
+        </p>
+      </section>
+
+      {speakers.length > 0 ? (
+        <section className="w-full">
+          <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+            {speakers.map((speaker) => (
+              <div
+                key={speaker.id}
+                className="flex flex-col items-center rounded-lg border border-gray-200 bg-white p-6 shadow-md"
+              >
+                <div className="mb-4 h-24 w-24 overflow-hidden rounded-full bg-gray-100">
+                  {speaker.image ? (
+                    <Image
+                      src={speaker.image}
+                      alt={`${speaker.name} ${speaker.surname}`}
+                      width={96}
+                      height={96}
+                      className="h-full w-full object-cover"
+                    />
+                  ) : (
+                    <div className="flex h-full w-full items-center justify-center text-2xl font-bold text-gray-400">
+                      {speaker.name.charAt(0)}
+                      {speaker.surname?.charAt(0)}
+                    </div>
+                  )}
+                </div>
+                <div className="text-center">
+                  <h2 className="text-lg font-semibold text-gray-900">
+                    {speaker.name} {speaker.surname}
+                  </h2>
+                  <p className="mt-1 text-sm text-purple">
+                    {speaker.events_count}x 🎤
+                  </p>
+                  <a
+                    href={speaker.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="mt-2 inline-flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700"
+                  >
+                    {t('speakers_page.view_profile')}
+                    <FaArrowUpRightFromSquare className="h-3 w-3" />
+                  </a>
+                </div>
+              </div>
+            ))}
+          </div>
+        </section>
+      ) : (
+        <p className="text-gray-500">{t('speakers_page.no_speakers')}</p>
+      )}
+
+      <p className="pb-8 text-sm text-gray-400">
+        {t('speakers_page.powered_by')}{' '}
+        <a
+          href="https://crossweb.pl"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline hover:text-gray-600"
+        >
+          Crossweb
+        </a>
+      </p>
+    </main>
+  );
+};
+
+export default SpeakersPage;

--- a/src/components/SpeakerFaces.tsx
+++ b/src/components/SpeakerFaces.tsx
@@ -1,0 +1,59 @@
+import Image from 'next/image';
+import Link from 'next/link';
+import type { Route } from 'next';
+import { getSpeakers } from '@/utils/getSpeakers';
+import { getTranslate } from '@/tolgee/server';
+
+export const SpeakerFaces = async () => {
+  const speakers = await getSpeakers();
+  const t = await getTranslate();
+
+  // Only show speakers that have images, limit to 60
+  const speakersWithImages = speakers.filter((s) => s.image).slice(0, 60);
+
+  if (speakersWithImages.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="w-full py-12 md:py-16">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="text-center">
+          <h2 className="mb-2 text-3xl font-bold">
+            {t('speakers_page.page_title')}
+          </h2>
+          <p className="mb-8 text-gray-600">
+            {speakers.length}+ {t('speaker_faces.community_members')}
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-center justify-center gap-2">
+          {speakersWithImages.map((speaker) => (
+            <div
+              key={speaker.id}
+              className="h-12 w-12 overflow-hidden rounded-full ring-2 ring-white transition-transform hover:scale-110 hover:ring-purple sm:h-14 sm:w-14"
+              title={`${speaker.name} ${speaker.surname || ''}`}
+            >
+              <Image
+                src={speaker.image!}
+                alt={`${speaker.name} ${speaker.surname || ''}`}
+                width={56}
+                height={56}
+                className="h-full w-full object-cover"
+              />
+            </div>
+          ))}
+        </div>
+
+        <div className="mt-8 text-center">
+          <Link
+            href={'/speakers' as Route}
+            className="inline-flex items-center gap-2 rounded-lg bg-purple px-6 py-3 font-semibold text-white transition-colors hover:bg-purple/80"
+          >
+            {t('speaker_faces.view_all')}
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+};

--- a/src/env.ts
+++ b/src/env.ts
@@ -6,8 +6,8 @@ export const env = createEnv({
     EVENTS_API_URL: z.string().url(),
     SITE_URL: z.string().url(),
     DISCORD_SERVER_ID: z.string(),
-    SPEAKERS_API_URL: z.string().url(),
-    SPEAKERS_API_TOKEN: z.string(),
+    SPEAKERS_API_URL: z.string().url().optional(),
+    SPEAKERS_API_TOKEN: z.string().optional(),
   },
   runtimeEnv: {
     EVENTS_API_URL: process.env.EVENTS_API_URL,

--- a/src/env.ts
+++ b/src/env.ts
@@ -6,10 +6,14 @@ export const env = createEnv({
     EVENTS_API_URL: z.string().url(),
     SITE_URL: z.string().url(),
     DISCORD_SERVER_ID: z.string(),
+    SPEAKERS_API_URL: z.string().url(),
+    SPEAKERS_API_TOKEN: z.string(),
   },
   runtimeEnv: {
     EVENTS_API_URL: process.env.EVENTS_API_URL,
     SITE_URL: process.env.SITE_URL,
     DISCORD_SERVER_ID: process.env.DISCORD_SERVER_ID,
+    SPEAKERS_API_URL: process.env.SPEAKERS_API_URL,
+    SPEAKERS_API_TOKEN: process.env.SPEAKERS_API_TOKEN,
   },
 });

--- a/src/hooks/useTranslatedMenuLinks.ts
+++ b/src/hooks/useTranslatedMenuLinks.ts
@@ -20,6 +20,12 @@ export const useTranslatedMenuLinks = (): MenuLink[] => {
       external: false,
     },
     {
+      name: t('navigation.menu_items.speakers'),
+      href: '/speakers',
+      current: false,
+      external: false,
+    },
+    {
       name: t('navigation.menu_items.cities'),
       href: '/events',
       current: false,

--- a/src/types/speaker.ts
+++ b/src/types/speaker.ts
@@ -1,0 +1,15 @@
+import { z } from 'zod';
+
+const SpeakerSchema = z.object({
+  id: z.number(),
+  name: z.string(),
+  surname: z.string().nullable().default(''),
+  slug: z.string(),
+  image: z.string().optional(),
+  events_count: z.number(),
+  url: z.string(),
+});
+
+export const SpeakersSchema = z.array(SpeakerSchema);
+
+export type SpeakerType = z.infer<typeof SpeakerSchema>;

--- a/src/utils/getSpeakers.ts
+++ b/src/utils/getSpeakers.ts
@@ -2,6 +2,9 @@ import { env } from '@/env';
 import { SpeakersSchema, SpeakerType } from '@/types/speaker';
 
 export const getSpeakers = async (): Promise<SpeakerType[]> => {
+  if (!env.SPEAKERS_API_URL || !env.SPEAKERS_API_TOKEN) {
+    return [];
+  }
   try {
     const res = await fetch(env.SPEAKERS_API_URL, {
       headers: {

--- a/src/utils/getSpeakers.ts
+++ b/src/utils/getSpeakers.ts
@@ -1,0 +1,23 @@
+import { env } from '@/env';
+import { SpeakersSchema, SpeakerType } from '@/types/speaker';
+
+export const getSpeakers = async (): Promise<SpeakerType[]> => {
+  try {
+    const res = await fetch(env.SPEAKERS_API_URL, {
+      headers: {
+        Authorization: `Basic ${env.SPEAKERS_API_TOKEN}`,
+      },
+      next: { revalidate: 3600 },
+    });
+
+    if (!res.ok) {
+      throw new Error(`HTTP error! status: ${res.status}`);
+    }
+
+    const json = await res.json();
+    return SpeakersSchema.parse(json);
+  } catch (error) {
+    console.error('Error fetching speakers:', error);
+    return [];
+  }
+};


### PR DESCRIPTION
Add new speakers page displaying all meet.js speakers with profile images and talk counts. Include speaker faces section on homepage showing community members. Integrate Crossweb API for speaker data with environment configuration and Zod schema validation.

<img width="1600" height="891" alt="signal-2026-05-06-151528" src="https://github.com/user-attachments/assets/260da647-9b8d-4efd-b0e7-83e191bc6f1b" />
<img width="3072" height="1838" alt="signal-2026-05-06-151939" src="https://github.com/user-attachments/assets/ec9e4519-9bdc-43c1-b636-c19d3d4ec066" />

