### PR TITLE
fix: remove noreferrer from external links

### DIFF
--- a/src/app/(pages)/14-birthday/page.tsx
+++ b/src/app/(pages)/14-birthday/page.tsx
@@ -135,7 +135,7 @@ export default function Page() {
               <a
                 href="https://web.archive.org/web/20110121031140/http://jsnews.pl/2011/01/18/meet-js-12-lutego-w-poznaniu/"
                 target="_blank"
-                rel="noopener noreferrer"
+                rel="noopener"
                 className="inline-flex items-center font-medium text-blue-600 transition-colors duration-200 hover:text-blue-800"
               >
                 <span>View original announcement</span>

--- a/src/app/(pages)/community-partnerships/page.tsx
+++ b/src/app/(pages)/community-partnerships/page.tsx
@@ -139,7 +139,7 @@ export default async function CommunityPartnershipsPage() {
                       <a
                         href={partnership.specialOffer.link}
                         target="_blank"
-                        rel="noopener noreferrer"
+                        rel="noopener"
                         className="inline-flex items-center gap-2 rounded-lg bg-gradient-to-r from-purple-600 to-blue-600 px-6 py-3 font-semibold text-white transition-all duration-200 hover:from-purple-700 hover:to-blue-700"
                       >
                         {partnership.specialOffer.linkText}
@@ -152,7 +152,7 @@ export default async function CommunityPartnershipsPage() {
                     <a
                       href={partnership.website}
                       target="_blank"
-                      rel="noopener noreferrer"
+                      rel="noopener"
                       className="inline-flex items-center gap-2 rounded-lg bg-blue-600 px-6 py-3 text-white transition-colors duration-200 hover:bg-blue-700"
                     >
                       {t('community_partnerships.visit_website')}
@@ -169,7 +169,7 @@ export default async function CommunityPartnershipsPage() {
                       <a
                         href={partnership.contact}
                         target="_blank"
-                        rel="noopener noreferrer"
+                        rel="noopener"
                         className="inline-flex items-center gap-2 rounded-lg border border-gray-300 px-6 py-3 text-gray-700 transition-colors duration-200 hover:bg-gray-50"
                       >
                         Learn More

--- a/src/app/(pages)/futureconf/page.tsx
+++ b/src/app/(pages)/futureconf/page.tsx
@@ -34,7 +34,7 @@ export default function FutureConfPage() {
               <a
                 href="https://futureconf.tech/meetjs/"
                 target="_blank"
-                rel="noopener noreferrer"
+                rel="noopener"
                 className="inline-flex items-center rounded-lg bg-white px-8 py-4 text-lg font-semibold text-purple-600 transition-all hover:scale-105 hover:bg-purple-50"
               >
                 Get Group Discount
@@ -103,7 +103,7 @@ export default function FutureConfPage() {
                     <a
                       href="https://futureconf.tech/meetjs/"
                       target="_blank"
-                      rel="noopener noreferrer"
+                      rel="noopener"
                       className="text-purple-600 hover:underline"
                     >
                       futureconf.tech/meetjs/
@@ -368,7 +368,7 @@ export default function FutureConfPage() {
             <a
               href="https://futureconf.tech/meetjs/"
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noopener"
               className="inline-flex items-center rounded-lg bg-white px-8 py-4 text-lg font-semibold text-purple-600 transition-all hover:scale-105 hover:bg-purple-50"
             >
               Get Group Discount Now

--- a/src/app/(pages)/jsnation-award/page.tsx
+++ b/src/app/(pages)/jsnation-award/page.tsx
@@ -152,7 +152,7 @@ export default function JSNationAwardPage() {
                 <a
                   href="https://www.linkedin.com/in/cdynak/?utm_source=meetjs.pl&utm_medium=referral&utm_campaign=community"
                   target="_blank"
-                  rel="noopener noreferrer"
+                  rel="noopener"
                 >
                   Cezary Dynak
                 </a>
@@ -161,7 +161,7 @@ export default function JSNationAwardPage() {
                 <a
                   href="https://www.linkedin.com/in/aleksandrapawlus/?utm_source=meetjs.pl&utm_medium=referral&utm_campaign=community"
                   target="_blank"
-                  rel="noopener noreferrer"
+                  rel="noopener"
                 >
                   Aleksandra Pawlus
                 </a>
@@ -170,7 +170,7 @@ export default function JSNationAwardPage() {
                 <a
                   href="https://www.linkedin.com/in/ssynowiecpl/?utm_source=meetjs.pl&utm_medium=referral&utm_campaign=community"
                   target="_blank"
-                  rel="noopener noreferrer"
+                  rel="noopener"
                 >
                   Stanisław Synowiec
                 </a>
@@ -193,7 +193,7 @@ export default function JSNationAwardPage() {
               <a
                 href="https://osawards.com/react/"
                 target="_blank"
-                rel="noopener noreferrer"
+                rel="noopener"
                 className="text-yellow-600 hover:text-yellow-700"
               >
                 React Open Source Awards
@@ -249,7 +249,7 @@ export default function JSNationAwardPage() {
             <a
               href="https://osawards.com/javascript/"
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noopener"
               className="inline-flex items-center gap-1 text-sm font-medium text-green-600 hover:text-green-700"
             >
               JavaScript Open Source Awards <ExternalLink className="h-3 w-3" />
@@ -257,7 +257,7 @@ export default function JSNationAwardPage() {
             <a
               href="https://jsnation.com/"
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noopener"
               className="inline-flex items-center gap-1 text-sm font-medium text-green-600 hover:text-green-700"
             >
               JSNation Conference
@@ -321,7 +321,7 @@ export default function JSNationAwardPage() {
               <a
                 href="https://www.meetup.com/javascript-london/"
                 target="_blank"
-                rel="noopener noreferrer"
+                rel="noopener"
                 className="inline-flex items-center gap-1 text-xs font-medium text-yellow-600 hover:text-yellow-700"
               >
                 Visit Meetup Page <ExternalLink className="h-3 w-3" />
@@ -343,7 +343,7 @@ export default function JSNationAwardPage() {
               <a
                 href="https://www.meetup.com/advancedjs-amsterdam/"
                 target="_blank"
-                rel="noopener noreferrer"
+                rel="noopener"
                 className="inline-flex items-center gap-1 text-xs font-medium text-yellow-600 hover:text-yellow-700"
               >
                 Visit Meetup Page <ExternalLink className="h-3 w-3" />
@@ -366,7 +366,7 @@ export default function JSNationAwardPage() {
               <a
                 href="https://www.meetup.com/copenhagenjs"
                 target="_blank"
-                rel="noopener noreferrer"
+                rel="noopener"
                 className="inline-flex items-center gap-1 text-xs font-medium text-yellow-600 hover:text-yellow-700"
               >
                 Visit Meetup Page <ExternalLink className="h-3 w-3" />
@@ -389,7 +389,7 @@ export default function JSNationAwardPage() {
             <a
               href={`https://x.com/intent/tweet?text=${encodeURIComponent('WE WON! meet.js Wrocław is the JavaScript Open Source Awards Community of the Year 2025! 🏆 So proud of our amazing community! #MeetjsWroclaw #JSAwardsWinner #CommunityOfTheYear #JavaScript')}`}
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noopener"
             >
               Share on Twitter
             </a>
@@ -402,7 +402,7 @@ export default function JSNationAwardPage() {
             <a
               href={`https://www.linkedin.com/sharing/share-offsite/?url=${encodeURIComponent('https://meet.js.pl/jsnation-award')}`}
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noopener"
             >
               Share on LinkedIn
             </a>
@@ -415,7 +415,7 @@ export default function JSNationAwardPage() {
             <a
               href={`https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent('https://meet.js.pl/jsnation-award')}`}
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noopener"
             >
               Share on Facebook
             </a>

--- a/src/app/(pages)/open-source/page.tsx
+++ b/src/app/(pages)/open-source/page.tsx
@@ -46,7 +46,7 @@ export default async function OpenSourcePage() {
                 <a
                   href="https://github.com/sponsors"
                   target="_blank"
-                  rel="noopener noreferrer"
+                  rel="noopener"
                   className="inline-flex h-10 items-center justify-center rounded-md bg-slate-900 px-4 py-2 text-sm font-medium text-white ring-offset-background transition-colors visited:text-white hover:bg-slate-800 hover:text-white focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
                 >
                   {t('open_source.support.platforms.github')}
@@ -54,7 +54,7 @@ export default async function OpenSourcePage() {
                 <a
                   href="https://opencollective.com/"
                   target="_blank"
-                  rel="noopener noreferrer"
+                  rel="noopener"
                   className="inline-flex h-10 items-center justify-center rounded-md border border-input bg-background px-4 py-2 text-sm font-medium ring-offset-background transition-colors hover:bg-accent hover:text-accent-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50"
                 >
                   {t('open_source.support.platforms.opencollective')}

--- a/src/app/(pages)/videos/page.tsx
+++ b/src/app/(pages)/videos/page.tsx
@@ -21,7 +21,7 @@ export default function VideosPage() {
             <a
               href="https://www.youtube.com/@meetjs"
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noopener"
               className="inline-flex items-center gap-2 rounded-lg bg-white px-8 py-4 text-lg font-semibold text-red-600 shadow-lg transition-colors duration-200 hover:bg-gray-100 hover:shadow-xl"
             >
               <FaYoutube className="h-6 w-6" />
@@ -87,7 +87,7 @@ export default function VideosPage() {
             <a
               href="https://www.youtube.com/@meetjs/videos"
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noopener"
               className="group overflow-hidden rounded-lg bg-white shadow-lg transition-all duration-300 hover:-translate-y-1 hover:shadow-xl dark:bg-gray-800"
             >
               <div className="flex aspect-video items-center justify-center bg-gradient-to-br from-red-500 to-red-700">
@@ -110,7 +110,7 @@ export default function VideosPage() {
             <a
               href="https://www.youtube.com/@meetjs/playlists"
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noopener"
               className="group overflow-hidden rounded-lg bg-white shadow-lg transition-all duration-300 hover:-translate-y-1 hover:shadow-xl dark:bg-gray-800"
             >
               <div className="flex aspect-video items-center justify-center bg-gradient-to-br from-purple-500 to-purple-700">
@@ -133,7 +133,7 @@ export default function VideosPage() {
             <a
               href="https://www.youtube.com/@meetjs/community"
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noopener"
               className="group overflow-hidden rounded-lg bg-white shadow-lg transition-all duration-300 hover:-translate-y-1 hover:shadow-xl dark:bg-gray-800"
             >
               <div className="flex aspect-video items-center justify-center bg-gradient-to-br from-green-500 to-green-700">

--- a/src/app/(pages)/wdi/page.tsx
+++ b/src/app/(pages)/wdi/page.tsx
@@ -136,7 +136,7 @@ export default function Page() {
           <a
             href="https://warszawskiedniinformatyki.pl/"
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noopener"
             className="text-primary hover:underline"
           >
             official website

--- a/src/app/30-years-of-javascript/page.tsx
+++ b/src/app/30-years-of-javascript/page.tsx
@@ -299,7 +299,7 @@ export default function JavaScript30Years() {
               <a
                 href="https://deno.com/blog/history-of-javascript"
                 target="_blank"
-                rel="noopener noreferrer"
+                rel="noopener"
                 className="rounded-full bg-white/20 px-8 py-4 font-medium text-gray-900 backdrop-blur-sm transition-all duration-300 hover:scale-105 hover:bg-white/30"
               >
                 Read the Full Story
@@ -409,7 +409,7 @@ export default function JavaScript30Years() {
                 <a
                   href="https://web.archive.org/web/20070916144913/http://wp.netscape.com/newsref/pr/newsrelease67.html"
                   target="_blank"
-                  rel="noopener noreferrer"
+                  rel="noopener"
                   className="inline-flex items-center gap-2 rounded-full bg-yellow-500 px-6 py-3 font-medium text-gray-900 transition-all duration-300 hover:scale-105 hover:bg-yellow-400"
                 >
                   <span>📜</span>
@@ -591,7 +591,7 @@ export default function JavaScript30Years() {
               <a
                 href="https://discord.gg/8r9XKTeNW8"
                 target="_blank"
-                rel="noopener noreferrer"
+                rel="noopener"
                 className="group rounded-full bg-indigo-600 px-8 py-4 font-medium text-white transition-all duration-300 hover:scale-105 hover:bg-indigo-700 hover:shadow-lg"
               >
                 <span className="flex items-center gap-2">
@@ -604,7 +604,7 @@ export default function JavaScript30Years() {
               <a
                 href="https://x.com/meetjs"
                 target="_blank"
-                rel="noopener noreferrer"
+                rel="noopener"
                 className="group rounded-full bg-blue-500 px-8 py-4 font-medium text-white transition-all duration-300 hover:scale-105 hover:bg-blue-600 hover:shadow-lg"
               >
                 <span className="flex items-center gap-2">

--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -97,7 +97,7 @@ export default async function Page() {
               <a
                 href="https://summit.meetjs.pl"
                 target="_blank"
-                rel="noopener noreferrer"
+                rel="noopener"
                 className="text-blue-600 hover:underline"
               >
                 {t('about.activities.summit.conference_link')}
@@ -120,7 +120,7 @@ export default async function Page() {
               <a
                 href="https://www.siepomaga.pl/pomagacze/meetjs"
                 target="_blank"
-                rel="noopener noreferrer"
+                rel="noopener"
                 className="text-blue-600 hover:underline"
               >
                 Siepomaga.pl

--- a/src/app/brand/page.tsx
+++ b/src/app/brand/page.tsx
@@ -569,7 +569,7 @@ const BrandPage = async () => {
           <Link
             href="https://github.com/meetjspl/brand-assets"
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noopener"
             className="inline-flex items-center gap-2 text-sm text-gray-600 hover:text-gray-800"
           >
             <FaGithub />

--- a/src/app/how-to-become-an-organizer/tools/page.tsx
+++ b/src/app/how-to-become-an-organizer/tools/page.tsx
@@ -24,7 +24,7 @@ export default async function OrganizerToolsPage() {
         <a
           href="https://meetjspl.github.io/assets-generator/"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noopener"
           className="inline-flex items-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-white transition-colors hover:bg-blue-700"
         >
           {t('organizer.generator_cta')}

--- a/src/app/organizers/page.tsx
+++ b/src/app/organizers/page.tsx
@@ -54,7 +54,7 @@ export default async function OrganizersPage() {
         <a
           href="https://discord.gg/8r9XKTeNW8"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noopener"
           className="rounded-lg border bg-purple-50 p-4 text-center transition-colors hover:bg-purple-100"
         >
           <ExternalLink className="mx-auto mb-2 h-6 w-6 text-purple-600" />
@@ -98,7 +98,7 @@ export default async function OrganizersPage() {
             <a
               href="https://meetjspl.github.io/assets-generator/"
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noopener"
               className="inline-flex items-center gap-2 rounded-md bg-purple-600 px-4 py-2 text-white transition-colors hover:bg-purple-700"
             >
               <Download className="h-4 w-4" />

--- a/src/app/speakers/page.tsx
+++ b/src/app/speakers/page.tsx
@@ -62,7 +62,7 @@ const SpeakersPage = async () => {
                   <a
                     href={speaker.url}
                     target="_blank"
-                    rel="noopener noreferrer"
+                    rel="noopener"
                     className="mt-2 inline-flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700"
                   >
                     {t('speakers_page.view_profile')}
@@ -82,7 +82,7 @@ const SpeakersPage = async () => {
         <a
           href="https://crossweb.pl"
           target="_blank"
-          rel="noopener noreferrer"
+          rel="noopener"
           className="underline hover:text-gray-600"
         >
           Crossweb

--- a/src/components/AISyncLogo.tsx
+++ b/src/components/AISyncLogo.tsx
@@ -7,7 +7,7 @@ export function AISyncLogo({ className = '' }: AISyncLogoProps) {
     <a
       href="https://www.aisyncconf.com"
       target="_blank"
-      rel="noopener noreferrer"
+      rel="noopener"
       className={`inline-flex items-center gap-2.5 no-underline ${className}`}
     >
       <span

--- a/src/components/ActionLink.tsx
+++ b/src/components/ActionLink.tsx
@@ -7,7 +7,7 @@ export const ActionLink = ({ href, children }: Props) => (
   <a
     href={href}
     target="_blank"
-    rel="noopener noreferrer"
+    rel="noopener"
     className="inline-flex items-center justify-center gap-2 rounded-full bg-primary px-4 py-2 text-primary-foreground transition-all hover:bg-purple/50"
   >
     {children}

--- a/src/components/CommunityItemCard.tsx
+++ b/src/components/CommunityItemCard.tsx
@@ -142,7 +142,7 @@ export const CommunityItemCard = ({ item }: { item: CommunityItem }) => {
           <a
             href={item.url}
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noopener"
             className={`group/btn flex items-center justify-center gap-2 rounded-2xl bg-gradient-to-r ${getTypeGradient(item.type)} px-6 py-3.5 font-bold text-white shadow-lg transition-all duration-300 hover:shadow-2xl hover:brightness-110`}
           >
             <span>{item.ctaText}</span>

--- a/src/components/DiscordInviteLink.tsx
+++ b/src/components/DiscordInviteLink.tsx
@@ -12,7 +12,7 @@ export const DiscordInviteLink = ({ href }: Props) => (
     onClick={trackDiscordInviteClick}
     href={href}
     target="_blank"
-    rel="noopener noreferrer"
+    rel="noopener"
     className="block w-full transform rounded-md bg-gradient-to-r from-[#5865F2] to-[#4752C4] py-3 text-center font-medium text-white shadow-md transition-all duration-300 hover:scale-[1.02] hover:from-[#4752C4] hover:to-[#3a45a5]"
   >
     Join Server

--- a/src/components/EventCard.tsx
+++ b/src/components/EventCard.tsx
@@ -54,7 +54,7 @@ export const EventCard = ({ event }: EventCardProps) => {
             <a
               href={event.url}
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noopener"
               className="transition-colors hover:text-purple dark:hover:text-green"
             >
               {event.name}
@@ -116,7 +116,7 @@ export const EventCard = ({ event }: EventCardProps) => {
             <a
               href={event.rsvp}
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noopener"
               className={cn(
                 buttonVariants({
                   size: 'sm',

--- a/src/components/EventDiscountSection.tsx
+++ b/src/components/EventDiscountSection.tsx
@@ -118,7 +118,7 @@ function EventPromoCard({ promo }: { promo: Promo }) {
             <a
               href={promo.eventLink}
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noopener"
               className="group flex cursor-pointer items-center justify-between rounded-lg border border-gray-200 p-3 transition-all duration-200 hover:border-purple-300 hover:bg-purple-50/50 dark:border-gray-600 dark:hover:border-purple-600 dark:hover:bg-purple-900/10"
               aria-label={`Visit ${promo.name} website`}
               onClick={(e) => e.stopPropagation()}
@@ -143,7 +143,7 @@ function EventPromoCard({ promo }: { promo: Promo }) {
           <a
             href={promo.ticketLink}
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noopener"
             className="block w-full rounded-lg bg-gradient-to-r from-purple-600 to-pink-600 py-3 text-center font-semibold text-white shadow transition-all duration-200 hover:-translate-y-0.5 hover:from-purple-700 hover:to-pink-700 hover:shadow-lg active:scale-95"
             onClick={(e) => e.stopPropagation()}
           >

--- a/src/components/FloatingSummitCTA.tsx
+++ b/src/components/FloatingSummitCTA.tsx
@@ -59,7 +59,7 @@ export const FloatingSummitCTA = () => {
               <a
                 href="https://summit.meetjs.pl/2026"
                 target="_blank"
-                rel="noopener noreferrer"
+                rel="noopener"
                 className="inline-block rounded-md bg-[#bcd35d] px-4 py-2 text-sm font-bold text-black transition-all hover:scale-105 hover:bg-[#bcd35d]/90 hover:shadow-lg"
               >
                 Get Tickets

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -96,7 +96,7 @@ export const Footer = async () => {
                       href={link.href}
                       className="hover:text-gray-300"
                       target="_blank"
-                      rel="noopener noreferrer"
+                      rel="noopener"
                     >
                       {link.name}
                       <FaArrowUpRightFromSquare
@@ -127,7 +127,7 @@ export const Footer = async () => {
             <a
               href="https://cyberfolks.pl/"
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noopener"
               className="transition-opacity hover:opacity-80"
             >
               {/* eslint-disable-next-line @next/next/no-img-element */}

--- a/src/components/HeroCarousel.tsx
+++ b/src/components/HeroCarousel.tsx
@@ -93,7 +93,7 @@ export const HeroCarousel = () => {
               <a
                 href="https://summit.meetjs.pl/2026"
                 target="_blank"
-                rel="noopener noreferrer"
+                rel="noopener"
                 className="mb-4 inline-flex items-center gap-2 rounded-full bg-gradient-to-r from-purple via-blue to-green px-4 py-2 text-sm font-semibold text-white shadow-lg transition-all hover:scale-105 hover:shadow-xl"
               >
                 <Sparkles className="h-4 w-4" />
@@ -111,7 +111,7 @@ export const HeroCarousel = () => {
                 <a
                   href="https://instagram.com/meet.js_poland"
                   target="_blank"
-                  rel="noopener noreferrer"
+                  rel="noopener"
                   className="flex items-center gap-2 rounded-full bg-white/20 px-4 py-2 text-sm backdrop-blur-sm transition-all hover:bg-white/30"
                 >
                   <Instagram className="h-4 w-4" />
@@ -120,7 +120,7 @@ export const HeroCarousel = () => {
                 <a
                   href="https://discord.gg/8r9XKTeNW8"
                   target="_blank"
-                  rel="noopener noreferrer"
+                  rel="noopener"
                   className="flex items-center gap-2 rounded-full bg-[#5865F2] px-4 py-2 text-sm transition-all hover:bg-[#4752C4] hover:shadow-md"
                 >
                   <MessagesSquare className="h-4 w-4" />
@@ -283,7 +283,7 @@ export const HeroCarousel = () => {
                   {/*<a*/}
                   {/*  href="https://summit.meetjs.pl/2026"*/}
                   {/*  target="_blank"*/}
-                  {/*  rel="noopener noreferrer"*/}
+                  {/*  rel="noopener"*/}
                   {/*  className="inline-block w-fit rounded-lg bg-[#bcd35d] px-8 py-4 text-base font-bold text-black transition-all hover:bg-[#bcd35d]/90 hover:shadow-lg hover:shadow-[#bcd35d]/20"*/}
                   {/*>*/}
                   {/*  {t('summit_2026.cta_get_tickets')}*/}
@@ -291,7 +291,7 @@ export const HeroCarousel = () => {
                   <a
                     href="https://summit.meetjs.pl/2026#speakers"
                     target="_blank"
-                    rel="noopener noreferrer"
+                    rel="noopener"
                     className="inline-flex items-center gap-2 rounded-lg border-2 border-white bg-white/10 px-8 py-4 text-base font-semibold text-white backdrop-blur-sm transition-all hover:bg-white/20"
                   >
                     {t('summit_2026.cta_view_speakers')}

--- a/src/components/LocalGroups.tsx
+++ b/src/components/LocalGroups.tsx
@@ -68,7 +68,7 @@ export const LocalGroups = ({ localGroups }: LocalGroupProps) => {
             key={localGroup}
             className="flex items-center justify-center gap-1"
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noopener"
           >
             {detectIcon(localGroup)}
           </a>

--- a/src/components/Navigation/DesktopNavigation.tsx
+++ b/src/components/Navigation/DesktopNavigation.tsx
@@ -97,7 +97,7 @@ export const DesktopNavigation = () => {
                           <a
                             href={dropdownItem.href}
                             target="_blank"
-                            rel="noopener noreferrer"
+                            rel="noopener"
                             className="flex items-center"
                           >
                             {dropdownItem.name}

--- a/src/components/Navigation/MobileNavigation.tsx
+++ b/src/components/Navigation/MobileNavigation.tsx
@@ -112,7 +112,7 @@ export const MobileNavigation = () => {
                                 }
                                 rel={
                                   dropdownItem.external
-                                    ? 'noopener noreferrer'
+                                    ? 'noopener'
                                     : undefined
                                 }
                               >
@@ -147,7 +147,7 @@ export const MobileNavigation = () => {
                     )}
                     aria-current={item.current ? 'page' : undefined}
                     target={item.external ? '_blank' : undefined}
-                    rel={item.external ? 'noopener noreferrer' : undefined}
+                    rel={item.external ? 'noopener' : undefined}
                     {...(item.external && {
                       'aria-label': `${item.name} (opens in a new tab)`,
                     })}

--- a/src/components/Navigation/NavigationLink.tsx
+++ b/src/components/Navigation/NavigationLink.tsx
@@ -40,7 +40,7 @@ export const NavigationLink = ({
       className={classNames(baseClasses, 'rounded-md px-3 py-2 font-medium')}
       aria-current={current ? 'page' : undefined}
       target="_blank"
-      rel="noopener noreferrer"
+      rel="noopener"
       itemProp="url"
       aria-label={`${name} (opens in a new tab)`}
     >

--- a/src/components/Organizers.tsx
+++ b/src/components/Organizers.tsx
@@ -47,7 +47,7 @@ export const Organizers = ({ city, organizers }: OrganizersProps) => {
                   <a
                     href={`mailto:${organizer.email}`}
                     target="_blank"
-                    rel="noopener noreferrer"
+                    rel="noopener"
                   >
                     <span className="sr-only">Email</span>@
                   </a>
@@ -56,7 +56,7 @@ export const Organizers = ({ city, organizers }: OrganizersProps) => {
                   <a
                     href={organizer.linkedin}
                     target="_blank"
-                    rel="noopener noreferrer"
+                    rel="noopener"
                   >
                     <span className="sr-only">Linkedin</span>
                     <FaLinkedin />
@@ -66,7 +66,7 @@ export const Organizers = ({ city, organizers }: OrganizersProps) => {
                   <a
                     href={organizer.gitHub}
                     target="_blank"
-                    rel="noopener noreferrer"
+                    rel="noopener"
                   >
                     <span className="sr-only">GitHub</span>
                     <FaGithub />

--- a/src/components/PartnersCarousel.tsx
+++ b/src/components/PartnersCarousel.tsx
@@ -23,7 +23,7 @@ export const PartnersCarousel = () => {
               href={partner.href}
               className="flex items-center justify-center"
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noopener"
             >
               {/* eslint-disable-next-line @next/next/no-img-element */}
               <img

--- a/src/components/PromoBanners.tsx
+++ b/src/components/PromoBanners.tsx
@@ -240,7 +240,7 @@ const LinkCTA = ({
     <a
       href={ticketLink}
       target="_blank"
-      rel="noopener noreferrer"
+      rel="noopener"
       className="inline-block rounded-full bg-white px-3 py-1 text-xs font-semibold text-purple shadow transition-colors duration-150 hover:bg-purple hover:text-white md:text-sm"
     >
       {cta}

--- a/src/components/PromoCard.tsx
+++ b/src/components/PromoCard.tsx
@@ -83,7 +83,7 @@ export function PromoCard({ promo }: PromoCardProps) {
             <a
               href={promo.eventLink || promo.ticketLink}
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noopener"
               className="font-medium text-white underline hover:text-white/90"
             >
               {getDomain(promo.eventLink || promo.ticketLink)}
@@ -96,7 +96,7 @@ export function PromoCard({ promo }: PromoCardProps) {
               <a
                 href={promo.ticketLink}
                 target="_blank"
-                rel="noopener noreferrer"
+                rel="noopener"
                 className="font-medium text-white underline hover:text-white/90"
               >
                 {getDomain(promo.ticketLink)}
@@ -111,7 +111,7 @@ export function PromoCard({ promo }: PromoCardProps) {
           <a
             href={promo.ticketLink}
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noopener"
             className="block w-full rounded-lg bg-white py-2 text-center font-semibold text-purple shadow transition-colors hover:bg-purple hover:text-white"
           >
             {promo.cta}

--- a/src/components/RankingBanner.tsx
+++ b/src/components/RankingBanner.tsx
@@ -8,7 +8,7 @@ export const RankingBanner = ({ href, text }: RankingBannerProps) => {
     <a
       href={href}
       target="_blank"
-      rel="noopener noreferrer"
+      rel="noopener"
       className="absolute right-4 top-4 hidden rotate-2 bg-blue px-4 py-2 shadow-lg transition-transform hover:scale-105 md:block"
     >
       <p className="text-sm font-bold">{text}</p>

--- a/src/components/Summit2026Banner.tsx
+++ b/src/components/Summit2026Banner.tsx
@@ -187,7 +187,7 @@ export const Summit2026Banner = () => {
             <a
               href="https://summit.meetjs.pl/2026"
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noopener"
               className="inline-block w-fit rounded-lg bg-[#bcd35d] px-8 py-4 text-base font-bold text-black transition-all hover:bg-[#bcd35d]/90 hover:shadow-lg hover:shadow-[#bcd35d]/20"
             >
               {t('summit_2026.cta_get_tickets')}
@@ -195,7 +195,7 @@ export const Summit2026Banner = () => {
             <a
               href="https://summit.meetjs.pl/2026#speakers"
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noopener"
               className="inline-flex items-center gap-2 rounded-lg border-2 border-white bg-white/10 px-8 py-4 text-base font-semibold text-white backdrop-blur-sm transition-all hover:bg-white/20"
             >
               {t('summit_2026.cta_view_speakers')}

--- a/src/components/UnifiedPromoCard.tsx
+++ b/src/components/UnifiedPromoCard.tsx
@@ -187,7 +187,7 @@ export default function UnifiedPromoCard({
                 <a
                   href={promo.eventLink}
                   target="_blank"
-                  rel="noopener noreferrer"
+                  rel="noopener"
                   className={config.linkColor}
                   onClick={(e) => e.stopPropagation()}
                 >
@@ -216,7 +216,7 @@ export default function UnifiedPromoCard({
                 <a
                   href={promo.eventLink}
                   target="_blank"
-                  rel="noopener noreferrer"
+                  rel="noopener"
                   className={config.linkColor}
                   onClick={(e) => e.stopPropagation()}
                 >
@@ -233,7 +233,7 @@ export default function UnifiedPromoCard({
           <a
             href={promo.ticketLink}
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noopener"
             className={`block w-full rounded-lg py-3 text-center font-semibold shadow transition-all hover:shadow-lg ${ctaTextColor} ${ctaGradient}`}
             onClick={(e) => e.stopPropagation()}
           >

--- a/src/components/WorkshopInfo.tsx
+++ b/src/components/WorkshopInfo.tsx
@@ -78,7 +78,7 @@ export default function WorkshopInfo({
           <a
             href={workshopLink}
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noopener"
             className="inline-flex items-center text-sm font-medium text-blue-600 hover:underline dark:text-blue-400"
           >
             Register for Workshop

--- a/src/components/YouTubeSubscribeBanner.tsx
+++ b/src/components/YouTubeSubscribeBanner.tsx
@@ -29,7 +29,7 @@ export const YouTubeSubscribeBanner = () => {
             <a
               href="/youtube"
               target="_blank"
-              rel="noopener noreferrer"
+              rel="noopener"
               className="inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-lg bg-white px-6 py-3 font-semibold text-red-600 shadow-lg transition-colors duration-200 hover:bg-gray-100 hover:shadow-xl"
             >
               <FaYoutube className="h-5 w-5" />

--- a/src/components/YouTubeVideos.tsx
+++ b/src/components/YouTubeVideos.tsx
@@ -56,7 +56,7 @@ export const YouTubeVideos = () => {
               <a
                 href="https://www.youtube.com/@meetjs/videos"
                 target="_blank"
-                rel="noopener noreferrer"
+                rel="noopener"
                 className="group overflow-hidden rounded-lg bg-white shadow-lg transition-all duration-300 hover:-translate-y-1 hover:shadow-xl dark:bg-gray-800"
               >
                 <div className="flex aspect-video items-center justify-center bg-gradient-to-br from-red-500 to-red-700">
@@ -78,7 +78,7 @@ export const YouTubeVideos = () => {
               <a
                 href="https://www.youtube.com/@meetjs/playlists"
                 target="_blank"
-                rel="noopener noreferrer"
+                rel="noopener"
                 className="group overflow-hidden rounded-lg bg-white shadow-lg transition-all duration-300 hover:-translate-y-1 hover:shadow-xl dark:bg-gray-800"
               >
                 <div className="flex aspect-video items-center justify-center bg-gradient-to-br from-purple-500 to-purple-700">
@@ -100,7 +100,7 @@ export const YouTubeVideos = () => {
               <a
                 href="https://www.youtube.com/@meetjs/community"
                 target="_blank"
-                rel="noopener noreferrer"
+                rel="noopener"
                 className="group overflow-hidden rounded-lg bg-white shadow-lg transition-all duration-300 hover:-translate-y-1 hover:shadow-xl dark:bg-gray-800"
               >
                 <div className="flex aspect-video items-center justify-center bg-gradient-to-br from-green-500 to-green-700">
@@ -127,7 +127,7 @@ export const YouTubeVideos = () => {
           <Link
             href="/youtube"
             target="_blank"
-            rel="noopener noreferrer"
+            rel="noopener"
             className="inline-flex items-center gap-2 rounded-lg bg-red-600 px-6 py-3 font-semibold text-white shadow-md transition-colors duration-200 hover:bg-red-700 hover:shadow-lg"
           >
             <FaYoutube className="h-5 w-5" />


### PR DESCRIPTION
Remove noreferrer from all external links to allow partners to see referrer traffic from meetjs.pl in their analytics.

Changes:
- Replaced rel="noopener noreferrer" with rel="noopener" in 36 files, 79 occurrences
- Keeps noopener for security (prevents window.opener access)
- Allows referrer data to pass to partner websites

Fixes #cursor-issue