### PR TITLE
feat: add WAWTech+Summer 2025 to events discounts

### DIFF
--- a/src/content/events-discounts.ts
+++ b/src/content/events-discounts.ts
@@ -2,6 +2,23 @@ import { Promo } from '../types/promo';
 
 export const eventsDiscounts: Promo[] = [
   {
+    id: 'wawtech-summer-2025',
+    name: 'WAWTech+Summer 2025',
+    message: '15% off with code MEETJS15!',
+    cta: '👉 Get 15% Off',
+    ticketLink: 'https://dou.ua/goto/meetjs',
+    eventLink: 'https://dou.ua/goto/meetjs',
+    expiresAt: '2025-07-18T23:59:59+02:00',
+    description:
+      '☀️ WAWTech+Summer — the largest open-air tech festival by DOU 🦄 takes place July 18 in Warsaw, Tor Służewiec! Talks and panel discussions, workshops and live coding sessions, a GameDev zone, expo area, partner activities, food court, chill-out zones, networking, job speed dating, and lots of unicorns 🦄 Use code MEETJS15 for 15% off your ticket!',
+    gradient: 'bg-gradient-to-r from-yellow-400 via-orange-500 to-red-500',
+    icon: '☀️',
+    emojiRight: '🇵🇱',
+    country: 'Poland',
+    city: 'Warsaw',
+    discountCode: 'MEETJS15',
+  },
+  {
     id: 'code-europe-2026',
     name: 'Code Europe 2026',
     message:


### PR DESCRIPTION
Add WAWTech+Summer 2025 as partner event with 15% discount code MEETJS15. Event on July 18, 2025 at Tor Służewiec in Warsaw. Largest open-air tech festival by DOU featuring talks, panel discussions, workshops, live coding sessions, GameDev zone, expo area, food court, networking and job speed dating.