### PR TITLE
feat: auto-expire community items past their endDate

### DIFF
--- a/src/content/communityParticipation.ts
+++ b/src/content/communityParticipation.ts
@@ -435,20 +435,30 @@ const sortByNewest = (items: CommunityItem[]): CommunityItem[] => {
   });
 };
 
+// An item is "past" once its endDate has elapsed. Items without an endDate
+// (e.g. open-ended surveys) never expire automatically.
+const isPastEvent = (item: CommunityItem): boolean =>
+  item.endDate ? new Date(item.endDate) < new Date() : false;
+
+// Currency is derived from the date, not only the manually-set status, so
+// items don't need their status flipped by hand once they finish.
+const isCurrentlyActive = (item: CommunityItem): boolean =>
+  item.status === 'active' && !isPastEvent(item);
+
 export const getActiveCommunityItems = (): CommunityItem[] => {
-  return sortByNewest(
-    COMMUNITY_PARTICIPATION.filter((item) => item.status === 'active'),
-  );
+  return sortByNewest(COMMUNITY_PARTICIPATION.filter(isCurrentlyActive));
 };
 
 export const getFeaturedCommunityItems = (): CommunityItem[] => {
   return sortByNewest(
     COMMUNITY_PARTICIPATION.filter(
-      (item) => item.featured && item.status === 'active',
+      (item) => item.featured && isCurrentlyActive(item),
     ),
   );
 };
 
+// Full archive: every item, past and present. Used by the /community page,
+// which intentionally lists completed initiatives alongside current ones.
 export const getCombinedCommunityItems = (): CommunityItem[] => {
   return sortByNewest([...COMMUNITY_PARTICIPATION]);
 };
@@ -456,6 +466,9 @@ export const getCombinedCommunityItems = (): CommunityItem[] => {
 export const getNewestCommunityItems = (limit: number = 3): CommunityItem[] => {
   const allItems = getCombinedCommunityItems();
 
-  // Filter featured items and slice (already sorted by getCombinedCommunityItems)
-  return allItems.filter((item) => item.featured).slice(0, limit);
+  // Only surface featured items that haven't already ended, so a finished
+  // event (with a now-dead "register" CTA) never shows up on the homepage.
+  return allItems
+    .filter((item) => item.featured && !isPastEvent(item))
+    .slice(0, limit);
 };


### PR DESCRIPTION
## What changed

Added date-based expiry to the community participation selectors in `src/content/communityParticipation.ts`:

- `isPastEvent(item)` — an item is past once its `endDate` has elapsed; items without an `endDate` (open-ended surveys) never auto-expire
- `getActiveCommunityItems`, `getFeaturedCommunityItems`, and `getNewestCommunityItems` (homepage) now skip past items
- `getCombinedCommunityItems` (the `/community` page) is intentionally unchanged — it still lists the full archive, completed initiatives included

## Why

Items keep `status: 'active'` after their events end unless someone remembers to flip them by hand. As of today, 5 finished events (Civil42, Superteam Poland, UGotIT, AI Sync 2026, Day One Ukraine) were still eligible for featured/active surfaces with dead registration CTAs. Deriving currency from `endDate` removes that manual maintenance step entirely — the same way `expiresAt` already works for discounts.

## Notes for the reviewer

- The filter evaluates `new Date()` at render time; pages are statically rendered, so items roll off on rebuild/revalidation rather than to-the-second. Day-level granularity is fine for events.
- Verified: `tsc --noEmit` clean, `pnpm test` 15/15 passing, and a runtime check confirms the homepage now surfaces only Testing Ground 2026, HackYeah 2026, and Code Europe 2026.
- Spotted in passing (not in this PR): `src/content/events-discounts.ts` has two entries with `id: 'cityjs-london-2026'` — a dormant React-key collision worth a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)