### PR TITLE
feat: add dedicated OG image for /discounts page

### DIFF
--- a/src/app/(pages)/discounts/layout.tsx
+++ b/src/app/(pages)/discounts/layout.tsx
@@ -16,13 +16,6 @@ export async function generateMetadata(): Promise<Metadata> {
       description: t('discounts.meta_description'),
       url: 'https://meetjs.pl/discounts',
       siteName: 'meet.js',
-      images: [
-        {
-          url: 'https://meetjs.pl/og-image.png',
-          width: 1200,
-          height: 630,
-        },
-      ],
       locale: 'en_US',
       type: 'website',
     },

--- a/src/app/(pages)/discounts/opengraph-image.tsx
+++ b/src/app/(pages)/discounts/opengraph-image.tsx
@@ -3,6 +3,7 @@ import { eventsDiscounts } from '@/content/events-discounts';
 import { softwareDiscounts } from '@/content/software-discounts';
 import { learningDiscounts } from '@/content/learning-discounts';
 import type { Promo } from '@/types/promo';
+import { getLogoDataUri } from '@/utils/og';
 
 export const alt = 'Exclusive discounts for the meet.js community';
 export const size = { width: 1200, height: 630 };
@@ -69,23 +70,9 @@ export default async function Image() {
           width: 720,
         }}
       >
-        {/* Wordmark */}
-        <div style={{ display: 'flex', alignItems: 'baseline' }}>
-          <span style={{ fontSize: 52, fontWeight: 700, color: '#ffffff' }}>
-            meet
-          </span>
-          <div
-            style={{
-              width: 14,
-              height: 14,
-              backgroundColor: '#bcd25f',
-              marginLeft: 4,
-              marginRight: 4,
-            }}
-          />
-          <span style={{ fontSize: 52, fontWeight: 700, color: '#239eab' }}>
-            js
-          </span>
+        {/* Logo */}
+        <div style={{ display: 'flex' }}>
+          <img src={getLogoDataUri()} width={240} height={67} alt="" />
         </div>
 
         {/* Headline */}

--- a/src/app/(pages)/discounts/opengraph-image.tsx
+++ b/src/app/(pages)/discounts/opengraph-image.tsx
@@ -1,0 +1,279 @@
+import { ImageResponse } from 'next/og';
+import { eventsDiscounts } from '@/content/events-discounts';
+import { softwareDiscounts } from '@/content/software-discounts';
+import { learningDiscounts } from '@/content/learning-discounts';
+import type { Promo } from '@/types/promo';
+
+export const alt = 'Exclusive discounts for the meet.js community';
+export const size = { width: 1200, height: 630 };
+export const contentType = 'image/png';
+
+const countActivePromos = (promos: Promo[]): number => {
+  const now = new Date();
+  return promos.filter((promo) => new Date(promo.expiresAt) >= now).length;
+};
+
+export default async function Image() {
+  const activeDeals = countActivePromos([
+    ...eventsDiscounts,
+    ...softwareDiscounts,
+    ...learningDiscounts,
+  ]);
+
+  return new ImageResponse(
+    <div
+      style={{
+        width: '100%',
+        height: '100%',
+        display: 'flex',
+        backgroundColor: '#2b1932',
+        backgroundImage:
+          'radial-gradient(circle at 85% 15%, rgba(35, 158, 171, 0.4), transparent 50%), radial-gradient(circle at 5% 95%, rgba(188, 210, 95, 0.3), transparent 45%)',
+        fontFamily: 'sans-serif',
+        position: 'relative',
+      }}
+    >
+      {/* Decorative percent signs */}
+      <div
+        style={{
+          position: 'absolute',
+          top: -40,
+          right: 340,
+          fontSize: 220,
+          fontWeight: 700,
+          color: 'rgba(255, 255, 255, 0.04)',
+        }}
+      >
+        %
+      </div>
+      <div
+        style={{
+          position: 'absolute',
+          bottom: -60,
+          left: 420,
+          fontSize: 280,
+          fontWeight: 700,
+          color: 'rgba(255, 255, 255, 0.04)',
+        }}
+      >
+        %
+      </div>
+
+      {/* Left column */}
+      <div
+        style={{
+          display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          padding: '64px 0 64px 72px',
+          width: 720,
+        }}
+      >
+        {/* Wordmark */}
+        <div style={{ display: 'flex', alignItems: 'baseline' }}>
+          <span style={{ fontSize: 52, fontWeight: 700, color: '#ffffff' }}>
+            meet
+          </span>
+          <div
+            style={{
+              width: 14,
+              height: 14,
+              backgroundColor: '#bcd25f',
+              marginLeft: 4,
+              marginRight: 4,
+            }}
+          />
+          <span style={{ fontSize: 52, fontWeight: 700, color: '#239eab' }}>
+            js
+          </span>
+        </div>
+
+        {/* Headline */}
+        <div style={{ display: 'flex', flexDirection: 'column' }}>
+          <span
+            style={{
+              fontSize: 84,
+              fontWeight: 700,
+              color: '#ffffff',
+              lineHeight: 1.05,
+            }}
+          >
+            Exclusive
+          </span>
+          <span
+            style={{
+              fontSize: 84,
+              fontWeight: 700,
+              lineHeight: 1.05,
+              backgroundImage: 'linear-gradient(90deg, #bcd25f, #239eab)',
+              backgroundClip: 'text',
+              color: 'transparent',
+            }}
+          >
+            Discounts
+          </span>
+          <span
+            style={{
+              fontSize: 28,
+              color: 'rgba(255, 255, 255, 0.75)',
+              marginTop: 24,
+              lineHeight: 1.4,
+            }}
+          >
+            Conference tickets, dev tools & learning platforms — free perks for
+            the Polish JavaScript community.
+          </span>
+        </div>
+
+        {/* Bottom row: badge + url */}
+        <div style={{ display: 'flex', alignItems: 'center' }}>
+          {activeDeals > 0 && (
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                border: '2px solid rgba(188, 210, 95, 0.6)',
+                borderRadius: 999,
+                padding: '10px 24px',
+                fontSize: 26,
+                color: '#bcd25f',
+                marginRight: 28,
+              }}
+            >
+              🎟 {activeDeals} {activeDeals === 1 ? 'deal' : 'deals'} live now
+            </div>
+          )}
+          <span style={{ fontSize: 26, color: 'rgba(255, 255, 255, 0.5)' }}>
+            meetjs.pl/discounts
+          </span>
+        </div>
+      </div>
+
+      {/* Right column: ticket */}
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          width: 480,
+        }}
+      >
+        <div
+          style={{
+            display: 'flex',
+            transform: 'rotate(6deg)',
+            backgroundImage: 'linear-gradient(135deg, #bcd25f, #239eab)',
+            borderRadius: 28,
+            padding: 4,
+            boxShadow: '0 30px 60px rgba(0, 0, 0, 0.5)',
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              backgroundColor: '#241329',
+              borderRadius: 24,
+              width: 340,
+              position: 'relative',
+            }}
+          >
+            {/* Ticket top */}
+            <div
+              style={{
+                display: 'flex',
+                flexDirection: 'column',
+                alignItems: 'center',
+                padding: '36px 32px 28px',
+              }}
+            >
+              <span
+                style={{
+                  fontSize: 20,
+                  letterSpacing: 6,
+                  color: 'rgba(255, 255, 255, 0.6)',
+                }}
+              >
+                COMMUNITY PERK
+              </span>
+              <span
+                style={{
+                  fontSize: 150,
+                  fontWeight: 700,
+                  lineHeight: 1,
+                  marginTop: 12,
+                  backgroundImage: 'linear-gradient(180deg, #bcd25f, #239eab)',
+                  backgroundClip: 'text',
+                  color: 'transparent',
+                }}
+              >
+                %
+              </span>
+            </div>
+
+            {/* Perforation */}
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                position: 'relative',
+                height: 0,
+                borderTop: '3px dashed rgba(255, 255, 255, 0.25)',
+              }}
+            />
+            <div
+              style={{
+                position: 'absolute',
+                left: -18,
+                top: 262,
+                width: 32,
+                height: 32,
+                borderRadius: 999,
+                backgroundColor: '#2b1932',
+              }}
+            />
+            <div
+              style={{
+                position: 'absolute',
+                right: -18,
+                top: 262,
+                width: 32,
+                height: 32,
+                borderRadius: 999,
+                backgroundColor: '#2b1932',
+              }}
+            />
+
+            {/* Ticket bottom */}
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                justifyContent: 'center',
+                padding: '28px 32px 36px',
+              }}
+            >
+              <div
+                style={{
+                  display: 'flex',
+                  backgroundColor: 'rgba(255, 255, 255, 0.08)',
+                  border: '2px solid rgba(255, 255, 255, 0.2)',
+                  borderRadius: 12,
+                  padding: '12px 24px',
+                  fontSize: 26,
+                  fontWeight: 700,
+                  letterSpacing: 3,
+                  color: '#ffffff',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                CODE: MEETJS
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>,
+    size,
+  );
+}

--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -1,177 +1,34 @@
 import { ImageResponse } from 'next/og';
-import { getLogoDataUri } from '@/utils/og';
+import { env } from '@/env';
 
 export const GET = async (request: Request) => {
   try {
     const { searchParams } = new URL(request.url);
 
     const hasCity = searchParams.has('city');
-    const city = hasCity
-      ? (searchParams.get('city')?.slice(0, 100) ?? 'Poland')
-      : 'Poland';
+    const city = hasCity ? searchParams.get('city')?.slice(0, 100) : 'Poland';
 
     return new ImageResponse(
       <div
         style={{
-          width: '100%',
-          height: '100%',
           display: 'flex',
-          flexDirection: 'column',
-          justifyContent: 'space-between',
-          backgroundColor: '#2b1932',
-          padding: '72px 0 56px 150px',
           position: 'relative',
-          fontFamily: 'sans-serif',
         }}
       >
-        {/* Decorative blocks */}
-        <div
+        {/* eslint-disable-next-line @next/next/no-img-element */}
+        <img
+          width="1200"
+          height="630"
+          src={`${env.SITE_URL}/assets/og-image-city.png`}
           style={{
             position: 'absolute',
-            top: 45,
-            right: 0,
-            width: 250,
-            height: 22,
-            backgroundColor: '#bcd25f',
-          }}
-        />
-        <div
-          style={{
-            position: 'absolute',
-            top: 315,
-            right: 80,
-            width: 205,
-            height: 55,
-            backgroundColor: '#219eab',
-          }}
-        />
-        <div
-          style={{
-            position: 'absolute',
-            top: 430,
-            right: 165,
-            width: 18,
-            height: 120,
-            backgroundColor: '#bcd25f',
-          }}
-        />
-        <div
-          style={{
-            position: 'absolute',
-            bottom: 20,
-            right: 45,
-            width: 55,
-            height: 80,
-            backgroundColor: '#219eab',
-          }}
-        />
-        <div
-          style={{
-            position: 'absolute',
-            bottom: 80,
+            top: 0,
             left: 0,
-            width: 45,
-            height: 45,
-            backgroundColor: '#bcd25f',
+            zIndex: 1,
           }}
+          alt=""
         />
-        <div
-          style={{
-            position: 'absolute',
-            top: 30,
-            left: 0,
-            width: 22,
-            height: 60,
-            backgroundColor: '#219eab',
-          }}
-        />
-
-        {/* Logo */}
-        <div style={{ display: 'flex' }}>
-          {/* eslint-disable-next-line @next/next/no-img-element */}
-          <img src={getLogoDataUri()} width={295} height={82} alt="" />
-        </div>
-
-        {/* Headline */}
-        <div
-          style={{
-            display: 'flex',
-            flexDirection: 'column',
-            marginBottom: 40,
-          }}
-        >
-          <div
-            style={{
-              display: 'flex',
-              position: 'relative',
-              alignSelf: 'flex-start',
-            }}
-          >
-            <div
-              style={{
-                position: 'absolute',
-                top: '38%',
-                bottom: '2%',
-                left: 60,
-                right: -120,
-                backgroundColor: '#219eab',
-              }}
-            />
-            <span
-              style={{
-                fontSize: 84,
-                fontWeight: 700,
-                color: '#ffffff',
-                lineHeight: 1.2,
-              }}
-            >
-              javascript meetups
-            </span>
-          </div>
-          <div
-            style={{
-              display: 'flex',
-              position: 'relative',
-              alignSelf: 'flex-start',
-              marginTop: 20,
-            }}
-          >
-            <div
-              style={{
-                position: 'absolute',
-                top: '30%',
-                bottom: '-6%',
-                left: -150,
-                right: -60,
-                backgroundColor: '#bcd25f',
-              }}
-            />
-            <span
-              style={{
-                fontSize: 84,
-                fontWeight: 700,
-                color: '#ffffff',
-                lineHeight: 1.2,
-              }}
-            >
-              in {city.toLowerCase()}
-            </span>
-          </div>
-        </div>
-
-        {/* Footer */}
-        <div style={{ display: 'flex', justifyContent: 'center' }}>
-          <span
-            style={{
-              fontSize: 38,
-              fontWeight: 700,
-              color: '#ffffff',
-              marginRight: 150,
-            }}
-          >
-            meetjs.pl
-          </span>
-        </div>
+        <p tw="text-white font-bold pt-77 pl-62 text-8xl">{city}</p>
       </div>,
       {
         width: 1200,

--- a/src/app/api/og/route.tsx
+++ b/src/app/api/og/route.tsx
@@ -1,34 +1,177 @@
 import { ImageResponse } from 'next/og';
-import { env } from '@/env';
+import { getLogoDataUri } from '@/utils/og';
 
 export const GET = async (request: Request) => {
   try {
     const { searchParams } = new URL(request.url);
 
     const hasCity = searchParams.has('city');
-    const city = hasCity ? searchParams.get('city')?.slice(0, 100) : 'Poland';
+    const city = hasCity
+      ? (searchParams.get('city')?.slice(0, 100) ?? 'Poland')
+      : 'Poland';
 
     return new ImageResponse(
       <div
         style={{
+          width: '100%',
+          height: '100%',
           display: 'flex',
+          flexDirection: 'column',
+          justifyContent: 'space-between',
+          backgroundColor: '#2b1932',
+          padding: '72px 0 56px 150px',
           position: 'relative',
+          fontFamily: 'sans-serif',
         }}
       >
-        {/* eslint-disable-next-line @next/next/no-img-element */}
-        <img
-          width="1200"
-          height="630"
-          src={`${env.SITE_URL}/assets/og-image-city.png`}
+        {/* Decorative blocks */}
+        <div
           style={{
             position: 'absolute',
-            top: 0,
-            left: 0,
-            zIndex: 1,
+            top: 45,
+            right: 0,
+            width: 250,
+            height: 22,
+            backgroundColor: '#bcd25f',
           }}
-          alt=""
         />
-        <p tw="text-white font-bold pt-77 pl-62 text-8xl">{city}</p>
+        <div
+          style={{
+            position: 'absolute',
+            top: 315,
+            right: 80,
+            width: 205,
+            height: 55,
+            backgroundColor: '#219eab',
+          }}
+        />
+        <div
+          style={{
+            position: 'absolute',
+            top: 430,
+            right: 165,
+            width: 18,
+            height: 120,
+            backgroundColor: '#bcd25f',
+          }}
+        />
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 20,
+            right: 45,
+            width: 55,
+            height: 80,
+            backgroundColor: '#219eab',
+          }}
+        />
+        <div
+          style={{
+            position: 'absolute',
+            bottom: 80,
+            left: 0,
+            width: 45,
+            height: 45,
+            backgroundColor: '#bcd25f',
+          }}
+        />
+        <div
+          style={{
+            position: 'absolute',
+            top: 30,
+            left: 0,
+            width: 22,
+            height: 60,
+            backgroundColor: '#219eab',
+          }}
+        />
+
+        {/* Logo */}
+        <div style={{ display: 'flex' }}>
+          {/* eslint-disable-next-line @next/next/no-img-element */}
+          <img src={getLogoDataUri()} width={295} height={82} alt="" />
+        </div>
+
+        {/* Headline */}
+        <div
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            marginBottom: 40,
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              position: 'relative',
+              alignSelf: 'flex-start',
+            }}
+          >
+            <div
+              style={{
+                position: 'absolute',
+                top: '38%',
+                bottom: '2%',
+                left: 60,
+                right: -120,
+                backgroundColor: '#219eab',
+              }}
+            />
+            <span
+              style={{
+                fontSize: 84,
+                fontWeight: 700,
+                color: '#ffffff',
+                lineHeight: 1.2,
+              }}
+            >
+              javascript meetups
+            </span>
+          </div>
+          <div
+            style={{
+              display: 'flex',
+              position: 'relative',
+              alignSelf: 'flex-start',
+              marginTop: 20,
+            }}
+          >
+            <div
+              style={{
+                position: 'absolute',
+                top: '30%',
+                bottom: '-6%',
+                left: -150,
+                right: -60,
+                backgroundColor: '#bcd25f',
+              }}
+            />
+            <span
+              style={{
+                fontSize: 84,
+                fontWeight: 700,
+                color: '#ffffff',
+                lineHeight: 1.2,
+              }}
+            >
+              in {city.toLowerCase()}
+            </span>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div style={{ display: 'flex', justifyContent: 'center' }}>
+          <span
+            style={{
+              fontSize: 38,
+              fontWeight: 700,
+              color: '#ffffff',
+              marginRight: 150,
+            }}
+          >
+            meetjs.pl
+          </span>
+        </div>
       </div>,
       {
         width: 1200,

--- a/src/utils/og.ts
+++ b/src/utils/og.ts
@@ -1,0 +1,11 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Inline the meet.js logo as a data URI so OG images render without
+ * network access (satori fetches <img> sources at render time).
+ */
+export const getLogoDataUri = (): string => {
+  const svg = readFileSync(join(process.cwd(), 'public', 'logo.svg'), 'utf8');
+  return `data:image/svg+xml;base64,${Buffer.from(svg).toString('base64')}`;
+};


### PR DESCRIPTION
## What changed

- Added `src/app/(pages)/discounts/opengraph-image.tsx` — a dedicated 1200×630 Open Graph image for the /discounts page, generated with `next/og` (`ImageResponse`) via the App Router file convention.
- Added `src/utils/og.ts` — inlines `public/logo.svg` as a data URI so the image uses the real meet.js wordmark without network access at render time.
- Removed the hardcoded generic `og-image.png` from the discounts layout metadata; the file convention now injects `og:image` (with width/height/alt and the Twitter card) automatically.

## Why

/discounts was sharing the generic site-wide OG image. Links shared on social media now get a branded card: the meet.js logo, gradient "Exclusive Discounts" headline, and a ticket graphic with a `CODE: MEETJS` chip.

The "deals live now" badge is computed at build time from the same content files the page renders (`events-discounts`, `software-discounts`, `learning-discounts`), filtered by `expiresAt` — so it stays in sync with every deploy. If no deals are active, the badge is omitted.

## Notes for reviewers

- Design constraints come from satori (flexbox-only CSS subset, default Noto Sans font).
- To preview locally: `pnpm dev`, open `/discounts`, and fetch the URL from the `og:image` meta tag.
- Verified locally: the page emits the correct `og:image` meta tags and the image renders as intended; `eslint` and `tsc --noEmit` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)