### PR TITLE
feat: remove Videos link from main navigation

### DIFF
--- a/src/hooks/useTranslatedMenuLinks.ts
+++ b/src/hooks/useTranslatedMenuLinks.ts
@@ -14,12 +14,6 @@ export const useTranslatedMenuLinks = (): MenuLink[] => {
       highlight: true,
     },
     {
-      name: t('navigation.menu_items.videos'),
-      href: '/videos',
-      current: false,
-      external: false,
-    },
-    {
       name: t('navigation.menu_items.speakers'),
       href: '/speakers',
       current: false,


### PR DESCRIPTION
## Summary
- Remove the Videos entry from the main navigation menu (no space for it anymore)
- The `/videos` page itself is untouched and still reachable by direct link

Generated with [Devin](https://devin.ai)